### PR TITLE
fix(tx3-cardano): infer plutus v2 hardcoded to right index

### DIFF
--- a/crates/tx3-cardano/src/compile/mod.rs
+++ b/crates/tx3-cardano/src/compile/mod.rs
@@ -482,7 +482,7 @@ fn compile_witness_set(
 
 fn infer_plutus_version(_transaction_body: &primitives::TransactionBody) -> PlutusVersion {
     // TODO: infer plutus version from existing scripts
-    return 2;
+    return 1;
 }
 
 fn compute_script_data_hash(


### PR DESCRIPTION
Plutus version index in the LanguageView struct starts on 0. All credit for the find goes to @alegadea 