### PR TITLE
feat(asset-def): add support for hex and string on asset def

### DIFF
--- a/crates/tx3-cardano/src/coercion.rs
+++ b/crates/tx3-cardano/src/coercion.rs
@@ -151,10 +151,7 @@ pub fn expr_into_address(
 pub fn expr_into_bytes(ir: &ir::Expression) -> Result<primitives::Bytes, Error> {
     match ir {
         ir::Expression::Bytes(x) => Ok(primitives::Bytes::from(x.clone())),
-        ir::Expression::String(s) => match hex::decode(s) {
-            Ok(x) => Ok(primitives::Bytes::from(x)),
-            Err(_) => Err(Error::CoerceError(format!("{:?}", ir), "Bytes".to_string())),
-        },
+        ir::Expression::String(s) => Ok(primitives::Bytes::from(s.as_bytes().to_vec())),
         _ => Err(Error::CoerceError(format!("{:?}", ir), "Bytes".to_string())),
     }
 }

--- a/crates/tx3-lang/src/analyzing.rs
+++ b/crates/tx3-lang/src/analyzing.rs
@@ -79,6 +79,7 @@ impl Error {
         match self {
             Self::NotInScope(x) => &x.span,
             Self::InvalidSymbol(x) => &x.span,
+            Self::InvalidType(x) => &x.span,
             _ => &Span::DUMMY,
         }
     }

--- a/crates/tx3-lang/src/analyzing.rs
+++ b/crates/tx3-lang/src/analyzing.rs
@@ -4,7 +4,6 @@
 //! duplicate definitions, unknown symbols, and other semantic errors.
 
 use std::{collections::HashMap, rc::Rc};
-use thiserror::Error;
 
 use crate::{ast::*, parsing::AstNode};
 
@@ -50,7 +49,7 @@ pub struct InvalidTypeError {
     span: Span,
 }
 
-#[derive(Error, Debug, miette::Diagnostic)]
+#[derive(thiserror::Error, Debug, miette::Diagnostic)]
 pub enum Error {
     #[error("duplicate definition: {0}")]
     #[diagnostic(code(tx3::duplicate_definition))]
@@ -663,13 +662,12 @@ fn dataexpr_to_bytes(val: &Option<DataExpr>, name: String) -> AnalyzeReport {
     match val {
         Some(DataExpr::String(_)) => AnalyzeReport::default(),
         Some(DataExpr::HexString(_)) => AnalyzeReport::default(),
-        Some(other) => bail_report!(Error::InvalidType(InvalidTypeError {
+        Some(other) => bail_report!(Error::invalid_type(
             name,
-            r#type: other.display_type(),
-            src: None,
-            expected: "String or Hex".to_string(),
-            span: other.span().clone(),
-        })),
+            other.display_type(),
+            "String or Hex".to_string(),
+            other,
+        )),
         None => AnalyzeReport::default(),
     }
 }

--- a/crates/tx3-lang/src/applying.rs
+++ b/crates/tx3-lang/src/applying.rs
@@ -727,6 +727,7 @@ impl ir::AssetExpr {
         match &self.asset_name {
             ir::Expression::None => None,
             ir::Expression::Bytes(x) => Some(x.as_slice()),
+            ir::Expression::String(x) => Some(x.as_bytes()),
             _ => None,
         }
     }

--- a/crates/tx3-lang/src/ast.rs
+++ b/crates/tx3-lang/src/ast.rs
@@ -741,18 +741,11 @@ impl VariantCase {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub enum AssetName {
-    Ascii(String),
-    String(StringLiteral),
-    HexString(HexStringLiteral),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AssetDef {
     pub name: String,
-    pub policy: Option<HexStringLiteral>,
-    pub asset_name: Option<AssetName>,
+    pub policy: Option<DataExpr>,
+    pub asset_name: Option<DataExpr>,
     pub span: Span,
 }
 

--- a/crates/tx3-lang/src/ast.rs
+++ b/crates/tx3-lang/src/ast.rs
@@ -742,10 +742,17 @@ impl VariantCase {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum AssetName {
+    Ascii(String),
+    String(StringLiteral),
+    HexString(HexStringLiteral),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct AssetDef {
     pub name: String,
     pub policy: Option<HexStringLiteral>,
-    pub asset_name: Option<String>,
+    pub asset_name: Option<AssetName>,
     pub span: Span,
 }
 

--- a/crates/tx3-lang/src/ir.rs
+++ b/crates/tx3-lang/src/ir.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Utxo, UtxoRef};
 
-pub const IR_VERSION: &str = "v1alpha4";
+pub const IR_VERSION: &str = "v1alpha5";
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct StructExpr {

--- a/crates/tx3-lang/src/lowering.rs
+++ b/crates/tx3-lang/src/lowering.rs
@@ -350,15 +350,8 @@ impl IntoLower for ast::StaticAssetConstructor {
     fn into_lower(&self) -> Result<Self::Output, Error> {
         let asset_def = coerce_identifier_into_asset_def(&self.r#type)?;
 
-        let policy = match asset_def.policy {
-            Some(x) => x.into_lower()?,
-            None => ir::Expression::None,
-        };
-
-        let asset_name = match asset_def.asset_name {
-            Some(x) => x.into_lower()?,
-            None => ir::Expression::None,
-        };
+        let policy = asset_def.policy.into_lower()?;
+        let asset_name = asset_def.asset_name.into_lower()?;
 
         let amount = self.amount.into_lower()?;
 

--- a/crates/tx3-lang/src/lowering.rs
+++ b/crates/tx3-lang/src/lowering.rs
@@ -356,7 +356,7 @@ impl IntoLower for ast::StaticAssetConstructor {
         };
 
         let asset_name = match asset_def.asset_name {
-            Some(x) => ir::Expression::Bytes(x.as_bytes().to_vec()),
+            Some(x) => x.into_lower()?,
             None => ir::Expression::None,
         };
 
@@ -401,6 +401,18 @@ impl IntoLower for ast::AssetBinaryOp {
                 ast::BinaryOperator::Subtract => ir::BinaryOpKind::Sub,
             },
         })
+    }
+}
+
+impl IntoLower for ast::AssetName {
+    type Output = ir::Expression;
+
+    fn into_lower(&self) -> Result<Self::Output, Error> {
+        match self {
+            ast::AssetName::Ascii(x) => Ok(ir::Expression::Bytes(x.as_bytes().to_vec())),
+            ast::AssetName::String(x) => Ok(ir::Expression::Bytes(x.value.as_bytes().to_vec())),
+            ast::AssetName::HexString(x) => Ok(ir::Expression::Bytes(hex::decode(&x.value)?)),
+        }
     }
 }
 

--- a/crates/tx3-lang/src/lowering.rs
+++ b/crates/tx3-lang/src/lowering.rs
@@ -351,7 +351,7 @@ impl IntoLower for ast::StaticAssetConstructor {
         let asset_def = coerce_identifier_into_asset_def(&self.r#type)?;
 
         let policy = match asset_def.policy {
-            Some(x) => ir::Expression::Bytes(hex::decode(&x.value)?),
+            Some(x) => x.into_lower()?,
             None => ir::Expression::None,
         };
 
@@ -401,18 +401,6 @@ impl IntoLower for ast::AssetBinaryOp {
                 ast::BinaryOperator::Subtract => ir::BinaryOpKind::Sub,
             },
         })
-    }
-}
-
-impl IntoLower for ast::AssetName {
-    type Output = ir::Expression;
-
-    fn into_lower(&self) -> Result<Self::Output, Error> {
-        match self {
-            ast::AssetName::Ascii(x) => Ok(ir::Expression::Bytes(x.as_bytes().to_vec())),
-            ast::AssetName::String(x) => Ok(ir::Expression::Bytes(x.value.as_bytes().to_vec())),
-            ast::AssetName::HexString(x) => Ok(ir::Expression::Bytes(hex::decode(&x.value)?)),
-        }
     }
 }
 

--- a/crates/tx3-lang/src/parsing.rs
+++ b/crates/tx3-lang/src/parsing.rs
@@ -1304,8 +1304,8 @@ impl AstNode for AssetDef {
 
         Ok(AssetDef {
             name: identifier,
-            policy: Some(policy),
-            asset_name: Some(asset_name),
+            policy,
+            asset_name,
             span,
         })
     }
@@ -1659,16 +1659,10 @@ mod tests {
         "asset MyToken = 0xef7a1cebb2dc7de884ddf82f8fcbc91fe9750dcd8c12ec7643a99bbe.0xef7a1ceb;",
         AssetDef {
             name: "MyToken".to_string(),
-            policy: Some(DataExpr::HexString(
-                HexStringLiteral::new(
-                    "ef7a1cebb2dc7de884ddf82f8fcbc91fe9750dcd8c12ec7643a99bbe".to_string()
-                )
+            policy: DataExpr::HexString(HexStringLiteral::new(
+                "ef7a1cebb2dc7de884ddf82f8fcbc91fe9750dcd8c12ec7643a99bbe".to_string()
             )),
-            asset_name: Some(DataExpr::HexString(
-                HexStringLiteral::new(
-                    "ef7a1ceb".to_string()
-                )
-            )),
+            asset_name: DataExpr::HexString(HexStringLiteral::new("ef7a1ceb".to_string())),
             span: Span::DUMMY,
         }
     );
@@ -1679,14 +1673,10 @@ mod tests {
         "asset MyToken = 0xef7a1cebb2dc7de884ddf82f8fcbc91fe9750dcd8c12ec7643a99bbe.\"MY TOKEN\";",
         AssetDef {
             name: "MyToken".to_string(),
-            policy: Some(DataExpr::HexString(
-                HexStringLiteral::new(
-                    "ef7a1cebb2dc7de884ddf82f8fcbc91fe9750dcd8c12ec7643a99bbe".to_string()
-                )
+            policy: DataExpr::HexString(HexStringLiteral::new(
+                "ef7a1cebb2dc7de884ddf82f8fcbc91fe9750dcd8c12ec7643a99bbe".to_string()
             )),
-            asset_name: Some(DataExpr::String(
-                StringLiteral::new("MY TOKEN".to_string())
-            )),
+            asset_name: DataExpr::String(StringLiteral::new("MY TOKEN".to_string())),
             span: Span::DUMMY,
         }
     );

--- a/crates/tx3-lang/src/parsing.rs
+++ b/crates/tx3-lang/src/parsing.rs
@@ -1299,15 +1299,8 @@ impl AstNode for AssetDef {
         let mut inner = pair.into_inner();
 
         let identifier = inner.next().unwrap().as_str().to_string();
-        let policy = HexStringLiteral::parse(inner.next().unwrap())?;
-        let asset_name = inner.next().unwrap();
-
-        let asset_name = match asset_name.as_rule() {
-            Rule::ascii_text => AssetName::Ascii(asset_name.as_str().to_string()),
-            Rule::string => AssetName::String(StringLiteral::parse(asset_name)?),
-            Rule::hex_string => AssetName::HexString(HexStringLiteral::parse(asset_name)?),
-            x => unreachable!("Unexpected rule in asset_def: {:?}", x),
-        };
+        let policy = DataExpr::parse(inner.next().unwrap())?;
+        let asset_name = DataExpr::parse(inner.next().unwrap())?;
 
         Ok(AssetDef {
             name: identifier,
@@ -1666,26 +1659,16 @@ mod tests {
         "asset MyToken = 0xef7a1cebb2dc7de884ddf82f8fcbc91fe9750dcd8c12ec7643a99bbe.0xef7a1ceb;",
         AssetDef {
             name: "MyToken".to_string(),
-            policy: Some(HexStringLiteral::new(
-                "ef7a1cebb2dc7de884ddf82f8fcbc91fe9750dcd8c12ec7643a99bbe".to_string()
+            policy: Some(DataExpr::HexString(
+                HexStringLiteral::new(
+                    "ef7a1cebb2dc7de884ddf82f8fcbc91fe9750dcd8c12ec7643a99bbe".to_string()
+                )
             )),
-            asset_name: Some(AssetName::HexString(HexStringLiteral::new(
-                "ef7a1ceb".to_string()
-            ))),
-            span: Span::DUMMY,
-        }
-    );
-
-    input_to_ast_check!(
-        AssetDef,
-        "hex_ascii",
-        "asset MyToken = 0xef7a1cebb2dc7de884ddf82f8fcbc91fe9750dcd8c12ec7643a99bbe.MYTOKEN;",
-        AssetDef {
-            name: "MyToken".to_string(),
-            policy: Some(HexStringLiteral::new(
-                "ef7a1cebb2dc7de884ddf82f8fcbc91fe9750dcd8c12ec7643a99bbe".to_string()
+            asset_name: Some(DataExpr::HexString(
+                HexStringLiteral::new(
+                    "ef7a1ceb".to_string()
+                )
             )),
-            asset_name: Some(AssetName::Ascii("MYTOKEN".to_string())),
             span: Span::DUMMY,
         }
     );
@@ -1696,10 +1679,14 @@ mod tests {
         "asset MyToken = 0xef7a1cebb2dc7de884ddf82f8fcbc91fe9750dcd8c12ec7643a99bbe.\"MY TOKEN\";",
         AssetDef {
             name: "MyToken".to_string(),
-            policy: Some(HexStringLiteral::new(
-                "ef7a1cebb2dc7de884ddf82f8fcbc91fe9750dcd8c12ec7643a99bbe".to_string()
+            policy: Some(DataExpr::HexString(
+                HexStringLiteral::new(
+                    "ef7a1cebb2dc7de884ddf82f8fcbc91fe9750dcd8c12ec7643a99bbe".to_string()
+                )
             )),
-            asset_name: Some(AssetName::String(StringLiteral::new("MY TOKEN".to_string()))),
+            asset_name: Some(DataExpr::String(
+                StringLiteral::new("MY TOKEN".to_string())
+            )),
             span: Span::DUMMY,
         }
     );
@@ -1940,7 +1927,7 @@ mod tests {
     #[test]
     fn test_spans_are_respected() {
         let program = parse_well_known_example("lang_tour");
-        assert_eq!(program.span, Span::new(0, 1320));
+        assert_eq!(program.span, Span::new(0, 1322));
 
         assert_eq!(program.parties[0].span, Span::new(0, 14));
 

--- a/crates/tx3-lang/src/tx3.pest
+++ b/crates/tx3-lang/src/tx3.pest
@@ -38,7 +38,7 @@ parameter_list = { "(" ~ (parameter ~ ("," ~ parameter)* ~ ","?)? ~ ")" }
 
 // Asset definitions
 asset_def = {
-    "asset" ~ identifier ~ "=" ~ hex_string ~ "." ~ ascii_text ~ ";"
+    "asset" ~ identifier ~ "=" ~ hex_string ~ "." ~ (hex_string | ascii_text | string) ~ ";"
 }
 
 // Party definitions

--- a/crates/tx3-lang/src/tx3.pest
+++ b/crates/tx3-lang/src/tx3.pest
@@ -3,7 +3,6 @@ COMMENT = _{ "//" ~ (!"\n" ~ ANY)* | "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
 
 // Identifiers and basic types
 identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
-ascii_text = @{ ASCII_ALPHANUMERIC+ }
 number = @{ "-"? ~ ASCII_DIGIT+ }
 string = @{ "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
 bool = @{ "true" | "false" }
@@ -38,7 +37,7 @@ parameter_list = { "(" ~ (parameter ~ ("," ~ parameter)* ~ ","?)? ~ ")" }
 
 // Asset definitions
 asset_def = {
-    "asset" ~ identifier ~ "=" ~ hex_string ~ "." ~ (hex_string | ascii_text | string) ~ ";"
+    "asset" ~ identifier ~ "=" ~ data_expr ~ "." ~ data_expr ~ ";"
 }
 
 // Party definitions

--- a/examples/asteria.ast
+++ b/examples/asteria.ast
@@ -805,7 +805,9 @@
           "end": 99
         }
       },
-      "asset_name": "FUEL",
+      "asset_name": {
+        "Ascii": "FUEL"
+      },
       "span": {
         "dummy": false,
         "start": 28,
@@ -822,7 +824,9 @@
           "end": 178
         }
       },
-      "asset_name": "SHIP",
+      "asset_name": {
+        "Ascii": "SHIP"
+      },
       "span": {
         "dummy": false,
         "start": 107,
@@ -839,7 +843,9 @@
           "end": 258
         }
       },
-      "asset_name": "PILOT",
+      "asset_name": {
+        "Ascii": "PILOT"
+      },
       "span": {
         "dummy": false,
         "start": 186,

--- a/examples/asteria.ast
+++ b/examples/asteria.ast
@@ -23,8 +23,8 @@
         ],
         "span": {
           "dummy": false,
-          "start": 581,
-          "end": 669
+          "start": 587,
+          "end": 675
         }
       },
       "references": [],
@@ -39,8 +39,8 @@
                   "value": "Game",
                   "span": {
                     "dummy": false,
-                    "start": 703,
-                    "end": 707
+                    "start": 709,
+                    "end": 713
                   }
                 }
               }
@@ -66,8 +66,8 @@
                         "value": "Ship",
                         "span": {
                           "dummy": false,
-                          "start": 758,
-                          "end": 762
+                          "start": 764,
+                          "end": 768
                         }
                       },
                       "amount": {
@@ -75,15 +75,15 @@
                           "value": "ship_name",
                           "span": {
                             "dummy": false,
-                            "start": 763,
-                            "end": 772
+                            "start": 769,
+                            "end": 778
                           }
                         }
                       },
                       "span": {
                         "dummy": false,
-                        "start": 758,
-                        "end": 776
+                        "start": 764,
+                        "end": 782
                       }
                     }
                   },
@@ -94,8 +94,8 @@
                         "value": "Fuel",
                         "span": {
                           "dummy": false,
-                          "start": 779,
-                          "end": 783
+                          "start": 785,
+                          "end": 789
                         }
                       },
                       "amount": {
@@ -103,22 +103,22 @@
                           "value": "required_fuel",
                           "span": {
                             "dummy": false,
-                            "start": 784,
-                            "end": 797
+                            "start": 790,
+                            "end": 803
                           }
                         }
                       },
                       "span": {
                         "dummy": false,
-                        "start": 779,
-                        "end": 798
+                        "start": 785,
+                        "end": 804
                       }
                     }
                   },
                   "span": {
                     "dummy": false,
-                    "start": 777,
-                    "end": 778
+                    "start": 783,
+                    "end": 784
                   }
                 }
               }
@@ -130,8 +130,8 @@
                     "value": "ShipCommand",
                     "span": {
                       "dummy": false,
-                      "start": 819,
-                      "end": 830
+                      "start": 825,
+                      "end": 836
                     }
                   },
                   "case": {
@@ -139,8 +139,8 @@
                       "value": "MoveShip",
                       "span": {
                         "dummy": false,
-                        "start": 832,
-                        "end": 840
+                        "start": 838,
+                        "end": 846
                       }
                     },
                     "fields": [
@@ -149,8 +149,8 @@
                           "value": "delta_x",
                           "span": {
                             "dummy": false,
-                            "start": 855,
-                            "end": 862
+                            "start": 861,
+                            "end": 868
                           }
                         },
                         "value": {
@@ -158,15 +158,15 @@
                             "value": "p_delta_x",
                             "span": {
                               "dummy": false,
-                              "start": 864,
-                              "end": 873
+                              "start": 870,
+                              "end": 879
                             }
                           }
                         },
                         "span": {
                           "dummy": false,
-                          "start": 855,
-                          "end": 873
+                          "start": 861,
+                          "end": 879
                         }
                       },
                       {
@@ -174,8 +174,8 @@
                           "value": "delta_y",
                           "span": {
                             "dummy": false,
-                            "start": 887,
-                            "end": 894
+                            "start": 893,
+                            "end": 900
                           }
                         },
                         "value": {
@@ -183,29 +183,29 @@
                             "value": "p_delta_y",
                             "span": {
                               "dummy": false,
-                              "start": 896,
-                              "end": 905
+                              "start": 902,
+                              "end": 911
                             }
                           }
                         },
                         "span": {
                           "dummy": false,
-                          "start": 887,
-                          "end": 905
+                          "start": 893,
+                          "end": 911
                         }
                       }
                     ],
                     "spread": null,
                     "span": {
                       "dummy": false,
-                      "start": 830,
-                      "end": 916
+                      "start": 836,
+                      "end": 922
                     }
                   },
                   "span": {
                     "dummy": false,
-                    "start": 819,
-                    "end": 916
+                    "start": 825,
+                    "end": 922
                   }
                 }
               }
@@ -213,8 +213,8 @@
           ],
           "span": {
             "dummy": false,
-            "start": 676,
-            "end": 923
+            "start": 682,
+            "end": 929
           }
         },
         {
@@ -227,8 +227,8 @@
                   "value": "Player",
                   "span": {
                     "dummy": false,
-                    "start": 957,
-                    "end": 963
+                    "start": 963,
+                    "end": 969
                   }
                 }
               }
@@ -240,8 +240,8 @@
                     "value": "Pilot",
                     "span": {
                       "dummy": false,
-                      "start": 985,
-                      "end": 990
+                      "start": 991,
+                      "end": 996
                     }
                   },
                   "amount": {
@@ -249,15 +249,15 @@
                       "value": "ship_name",
                       "span": {
                         "dummy": false,
-                        "start": 991,
-                        "end": 1000
+                        "start": 997,
+                        "end": 1006
                       }
                     }
                   },
                   "span": {
                     "dummy": false,
-                    "start": 985,
-                    "end": 1004
+                    "start": 991,
+                    "end": 1010
                   }
                 }
               }
@@ -265,8 +265,8 @@
           ],
           "span": {
             "dummy": false,
-            "start": 929,
-            "end": 1011
+            "start": 935,
+            "end": 1017
           }
         },
         {
@@ -279,8 +279,8 @@
                   "value": "Player",
                   "span": {
                     "dummy": false,
-                    "start": 1048,
-                    "end": 1054
+                    "start": 1054,
+                    "end": 1060
                   }
                 }
               }
@@ -291,8 +291,8 @@
                   "value": "fees",
                   "span": {
                     "dummy": false,
-                    "start": 1076,
-                    "end": 1080
+                    "start": 1082,
+                    "end": 1086
                   }
                 }
               }
@@ -300,8 +300,8 @@
           ],
           "span": {
             "dummy": false,
-            "start": 1021,
-            "end": 1087
+            "start": 1027,
+            "end": 1093
           }
         }
       ],
@@ -315,8 +315,8 @@
                   "value": "Game",
                   "span": {
                     "dummy": false,
-                    "start": 1173,
-                    "end": 1177
+                    "start": 1179,
+                    "end": 1183
                   }
                 }
               }
@@ -329,8 +329,8 @@
                       "value": "ship",
                       "span": {
                         "dummy": false,
-                        "start": 1195,
-                        "end": 1199
+                        "start": 1201,
+                        "end": 1205
                       }
                     }
                   },
@@ -341,8 +341,8 @@
                         "value": "Fuel",
                         "span": {
                           "dummy": false,
-                          "start": 1202,
-                          "end": 1206
+                          "start": 1208,
+                          "end": 1212
                         }
                       },
                       "amount": {
@@ -350,22 +350,22 @@
                           "value": "required_fuel",
                           "span": {
                             "dummy": false,
-                            "start": 1207,
-                            "end": 1220
+                            "start": 1213,
+                            "end": 1226
                           }
                         }
                       },
                       "span": {
                         "dummy": false,
-                        "start": 1202,
-                        "end": 1221
+                        "start": 1208,
+                        "end": 1227
                       }
                     }
                   },
                   "span": {
                     "dummy": false,
-                    "start": 1200,
-                    "end": 1201
+                    "start": 1206,
+                    "end": 1207
                   }
                 }
               }
@@ -377,8 +377,8 @@
                     "value": "ShipState",
                     "span": {
                       "dummy": false,
-                      "start": 1239,
-                      "end": 1248
+                      "start": 1245,
+                      "end": 1254
                     }
                   },
                   "case": {
@@ -396,8 +396,8 @@
                           "value": "pos_x",
                           "span": {
                             "dummy": false,
-                            "start": 1263,
-                            "end": 1268
+                            "start": 1269,
+                            "end": 1274
                           }
                         },
                         "value": {
@@ -408,8 +408,8 @@
                                   "value": "ship",
                                   "span": {
                                     "dummy": false,
-                                    "start": 1270,
-                                    "end": 1274
+                                    "start": 1276,
+                                    "end": 1280
                                   }
                                 },
                                 "path": [
@@ -417,15 +417,15 @@
                                     "value": "pos_x",
                                     "span": {
                                       "dummy": false,
-                                      "start": 1275,
-                                      "end": 1280
+                                      "start": 1281,
+                                      "end": 1286
                                     }
                                   }
                                 ],
                                 "span": {
                                   "dummy": false,
-                                  "start": 1270,
-                                  "end": 1281
+                                  "start": 1276,
+                                  "end": 1287
                                 }
                               }
                             },
@@ -435,22 +435,22 @@
                                 "value": "p_delta_x",
                                 "span": {
                                   "dummy": false,
-                                  "start": 1283,
-                                  "end": 1292
+                                  "start": 1289,
+                                  "end": 1298
                                 }
                               }
                             },
                             "span": {
                               "dummy": false,
-                              "start": 1281,
-                              "end": 1282
+                              "start": 1287,
+                              "end": 1288
                             }
                           }
                         },
                         "span": {
                           "dummy": false,
-                          "start": 1263,
-                          "end": 1292
+                          "start": 1269,
+                          "end": 1298
                         }
                       },
                       {
@@ -458,8 +458,8 @@
                           "value": "pos_y",
                           "span": {
                             "dummy": false,
-                            "start": 1306,
-                            "end": 1311
+                            "start": 1312,
+                            "end": 1317
                           }
                         },
                         "value": {
@@ -470,8 +470,8 @@
                                   "value": "ship",
                                   "span": {
                                     "dummy": false,
-                                    "start": 1313,
-                                    "end": 1317
+                                    "start": 1319,
+                                    "end": 1323
                                   }
                                 },
                                 "path": [
@@ -479,15 +479,15 @@
                                     "value": "pos_y",
                                     "span": {
                                       "dummy": false,
-                                      "start": 1318,
-                                      "end": 1323
+                                      "start": 1324,
+                                      "end": 1329
                                     }
                                   }
                                 ],
                                 "span": {
                                   "dummy": false,
-                                  "start": 1313,
-                                  "end": 1324
+                                  "start": 1319,
+                                  "end": 1330
                                 }
                               }
                             },
@@ -497,22 +497,22 @@
                                 "value": "p_delta_y",
                                 "span": {
                                   "dummy": false,
-                                  "start": 1326,
-                                  "end": 1335
+                                  "start": 1332,
+                                  "end": 1341
                                 }
                               }
                             },
                             "span": {
                               "dummy": false,
-                              "start": 1324,
-                              "end": 1325
+                              "start": 1330,
+                              "end": 1331
                             }
                           }
                         },
                         "span": {
                           "dummy": false,
-                          "start": 1306,
-                          "end": 1335
+                          "start": 1312,
+                          "end": 1341
                         }
                       }
                     ],
@@ -521,21 +521,21 @@
                         "value": "ship",
                         "span": {
                           "dummy": false,
-                          "start": 1352,
-                          "end": 1356
+                          "start": 1358,
+                          "end": 1362
                         }
                       }
                     },
                     "span": {
                       "dummy": false,
-                      "start": 1249,
-                      "end": 1366
+                      "start": 1255,
+                      "end": 1372
                     }
                   },
                   "span": {
                     "dummy": false,
-                    "start": 1239,
-                    "end": 1366
+                    "start": 1245,
+                    "end": 1372
                   }
                 }
               }
@@ -543,8 +543,8 @@
           ],
           "span": {
             "dummy": false,
-            "start": 1152,
-            "end": 1373
+            "start": 1158,
+            "end": 1379
           }
         },
         {
@@ -556,8 +556,8 @@
                   "value": "Player",
                   "span": {
                     "dummy": false,
-                    "start": 1400,
-                    "end": 1406
+                    "start": 1406,
+                    "end": 1412
                   }
                 }
               }
@@ -570,8 +570,8 @@
                       "value": "pilot",
                       "span": {
                         "dummy": false,
-                        "start": 1424,
-                        "end": 1429
+                        "start": 1430,
+                        "end": 1435
                       }
                     }
                   },
@@ -581,15 +581,15 @@
                       "value": "fees",
                       "span": {
                         "dummy": false,
-                        "start": 1432,
-                        "end": 1436
+                        "start": 1438,
+                        "end": 1442
                       }
                     }
                   },
                   "span": {
                     "dummy": false,
-                    "start": 1430,
-                    "end": 1431
+                    "start": 1436,
+                    "end": 1437
                   }
                 }
               }
@@ -597,8 +597,8 @@
           ],
           "span": {
             "dummy": false,
-            "start": 1379,
-            "end": 1443
+            "start": 1385,
+            "end": 1449
           }
         }
       ],
@@ -612,8 +612,8 @@
                   "value": "Fuel",
                   "span": {
                     "dummy": false,
-                    "start": 1116,
-                    "end": 1120
+                    "start": 1122,
+                    "end": 1126
                   }
                 },
                 "amount": {
@@ -621,15 +621,15 @@
                     "value": "required_fuel",
                     "span": {
                       "dummy": false,
-                      "start": 1121,
-                      "end": 1134
+                      "start": 1127,
+                      "end": 1140
                     }
                   }
                 },
                 "span": {
                   "dummy": false,
-                  "start": 1116,
-                  "end": 1135
+                  "start": 1122,
+                  "end": 1141
                 }
               }
             }
@@ -637,16 +637,16 @@
         ],
         "span": {
           "dummy": false,
-          "start": 1093,
-          "end": 1142
+          "start": 1099,
+          "end": 1148
         }
       },
       "mints": [],
       "adhoc": [],
       "span": {
         "dummy": false,
-        "start": 569,
-        "end": 1445
+        "start": 575,
+        "end": 1451
       },
       "collateral": [],
       "metadata": null
@@ -664,8 +664,8 @@
               "type": "Int",
               "span": {
                 "dummy": false,
-                "start": 288,
-                "end": 298
+                "start": 294,
+                "end": 304
               }
             },
             {
@@ -673,8 +673,8 @@
               "type": "Int",
               "span": {
                 "dummy": false,
-                "start": 304,
-                "end": 314
+                "start": 310,
+                "end": 320
               }
             },
             {
@@ -682,8 +682,8 @@
               "type": "Bytes",
               "span": {
                 "dummy": false,
-                "start": 320,
-                "end": 342
+                "start": 326,
+                "end": 348
               }
             },
             {
@@ -691,8 +691,8 @@
               "type": "Bytes",
               "span": {
                 "dummy": false,
-                "start": 348,
-                "end": 371
+                "start": 354,
+                "end": 377
               }
             },
             {
@@ -700,22 +700,22 @@
               "type": "Int",
               "span": {
                 "dummy": false,
-                "start": 377,
-                "end": 403
+                "start": 383,
+                "end": 409
               }
             }
           ],
           "span": {
             "dummy": false,
-            "start": 267,
-            "end": 406
+            "start": 273,
+            "end": 412
           }
         }
       ],
       "span": {
         "dummy": false,
-        "start": 267,
-        "end": 406
+        "start": 273,
+        "end": 412
       }
     },
     {
@@ -729,8 +729,8 @@
               "type": "Int",
               "span": {
                 "dummy": false,
-                "start": 451,
-                "end": 463
+                "start": 457,
+                "end": 469
               }
             },
             {
@@ -738,15 +738,15 @@
               "type": "Int",
               "span": {
                 "dummy": false,
-                "start": 473,
-                "end": 485
+                "start": 479,
+                "end": 491
               }
             }
           ],
           "span": {
             "dummy": false,
-            "start": 431,
-            "end": 492
+            "start": 437,
+            "end": 498
           }
         },
         {
@@ -757,15 +757,15 @@
               "type": "Int",
               "span": {
                 "dummy": false,
-                "start": 519,
-                "end": 530
+                "start": 525,
+                "end": 536
               }
             }
           ],
           "span": {
             "dummy": false,
-            "start": 498,
-            "end": 537
+            "start": 504,
+            "end": 543
           }
         },
         {
@@ -773,8 +773,8 @@
           "fields": [],
           "span": {
             "dummy": false,
-            "start": 543,
-            "end": 554
+            "start": 549,
+            "end": 560
           }
         },
         {
@@ -782,15 +782,15 @@
           "fields": [],
           "span": {
             "dummy": false,
-            "start": 560,
-            "end": 564
+            "start": 566,
+            "end": 570
           }
         }
       ],
       "span": {
         "dummy": false,
-        "start": 408,
-        "end": 567
+        "start": 414,
+        "end": 573
       }
     }
   ],
@@ -798,58 +798,85 @@
     {
       "name": "Fuel",
       "policy": {
-        "value": "6b9c456aa650cb808a9ab54326e039d5235ed69f069c9664a8fe5b69",
-        "span": {
-          "dummy": false,
-          "start": 41,
-          "end": 99
+        "HexString": {
+          "value": "6b9c456aa650cb808a9ab54326e039d5235ed69f069c9664a8fe5b69",
+          "span": {
+            "dummy": false,
+            "start": 41,
+            "end": 99
+          }
         }
       },
       "asset_name": {
-        "Ascii": "FUEL"
+        "String": {
+          "value": "FUEL",
+          "span": {
+            "dummy": false,
+            "start": 100,
+            "end": 106
+          }
+        }
       },
       "span": {
         "dummy": false,
         "start": 28,
-        "end": 105
+        "end": 107
       }
     },
     {
       "name": "Ship",
       "policy": {
-        "value": "6b9c456aa650cb808a9ab54326e039d5235ed69f069c9664a8fe5b69",
-        "span": {
-          "dummy": false,
-          "start": 120,
-          "end": 178
+        "HexString": {
+          "value": "6b9c456aa650cb808a9ab54326e039d5235ed69f069c9664a8fe5b69",
+          "span": {
+            "dummy": false,
+            "start": 122,
+            "end": 180
+          }
         }
       },
       "asset_name": {
-        "Ascii": "SHIP"
+        "String": {
+          "value": "SHIP",
+          "span": {
+            "dummy": false,
+            "start": 181,
+            "end": 187
+          }
+        }
       },
       "span": {
         "dummy": false,
-        "start": 107,
-        "end": 184
+        "start": 109,
+        "end": 188
       }
     },
     {
       "name": "Pilot",
       "policy": {
-        "value": "6b9c456aa650cb808a9ab54326e039d5235ed69f069c9664a8fe5b69",
-        "span": {
-          "dummy": false,
-          "start": 200,
-          "end": 258
+        "HexString": {
+          "value": "6b9c456aa650cb808a9ab54326e039d5235ed69f069c9664a8fe5b69",
+          "span": {
+            "dummy": false,
+            "start": 204,
+            "end": 262
+          }
         }
       },
       "asset_name": {
-        "Ascii": "PILOT"
+        "String": {
+          "value": "PILOT",
+          "span": {
+            "dummy": false,
+            "start": 263,
+            "end": 270
+          }
+        }
       },
       "span": {
         "dummy": false,
-        "start": 186,
-        "end": 265
+        "start": 190,
+        "end": 271
       }
     }
   ],
@@ -875,6 +902,6 @@
   "span": {
     "dummy": false,
     "start": 0,
-    "end": 1445
+    "end": 1451
   }
 }

--- a/examples/asteria.move_ship.tir
+++ b/examples/asteria.move_ship.tir
@@ -49,12 +49,7 @@
                     ]
                   },
                   "asset_name": {
-                    "Bytes": [
-                      83,
-                      72,
-                      73,
-                      80
-                    ]
+                    "String": "SHIP"
                   },
                   "amount": {
                     "EvalParameter": [
@@ -101,12 +96,7 @@
                     ]
                   },
                   "asset_name": {
-                    "Bytes": [
-                      70,
-                      85,
-                      69,
-                      76
-                    ]
+                    "String": "FUEL"
                   },
                   "amount": {
                     "EvalParameter": [
@@ -189,13 +179,7 @@
                 ]
               },
               "asset_name": {
-                "Bytes": [
-                  80,
-                  73,
-                  76,
-                  79,
-                  84
-                ]
+                "String": "PILOT"
               },
               "amount": {
                 "EvalParameter": [
@@ -349,12 +333,7 @@
                   ]
                 },
                 "asset_name": {
-                  "Bytes": [
-                    70,
-                    85,
-                    69,
-                    76
-                  ]
+                  "String": "FUEL"
                 },
                 "amount": {
                   "EvalParameter": [

--- a/examples/asteria.tx3
+++ b/examples/asteria.tx3
@@ -2,11 +2,11 @@ party Player;
 
 party Game;
 
-asset Fuel = 0x6b9c456aa650cb808a9ab54326e039d5235ed69f069c9664a8fe5b69.FUEL;
+asset Fuel = 0x6b9c456aa650cb808a9ab54326e039d5235ed69f069c9664a8fe5b69."FUEL";
 
-asset Ship = 0x6b9c456aa650cb808a9ab54326e039d5235ed69f069c9664a8fe5b69.SHIP;
+asset Ship = 0x6b9c456aa650cb808a9ab54326e039d5235ed69f069c9664a8fe5b69."SHIP";
 
-asset Pilot = 0x6b9c456aa650cb808a9ab54326e039d5235ed69f069c9664a8fe5b69.PILOT;
+asset Pilot = 0x6b9c456aa650cb808a9ab54326e039d5235ed69f069c9664a8fe5b69."PILOT";
 
 type ShipState {
     pos_x: Int,

--- a/examples/faucet.ast
+++ b/examples/faucet.ast
@@ -15,8 +15,8 @@
         ],
         "span": {
           "dummy": false,
-          "start": 210,
-          "end": 252
+          "start": 212,
+          "end": 254
         }
       },
       "references": [],
@@ -31,8 +31,8 @@
                   "value": "Requester",
                   "span": {
                     "dummy": false,
-                    "start": 294,
-                    "end": 303
+                    "start": 296,
+                    "end": 305
                   }
                 }
               }
@@ -43,8 +43,8 @@
                   "value": "fees",
                   "span": {
                     "dummy": false,
-                    "start": 325,
-                    "end": 329
+                    "start": 327,
+                    "end": 331
                   }
                 }
               }
@@ -52,8 +52,8 @@
           ],
           "span": {
             "dummy": false,
-            "start": 259,
-            "end": 336
+            "start": 261,
+            "end": 338
           }
         }
       ],
@@ -67,8 +67,8 @@
                   "value": "Requester",
                   "span": {
                     "dummy": false,
-                    "start": 448,
-                    "end": 457
+                    "start": 450,
+                    "end": 459
                   }
                 }
               }
@@ -83,8 +83,8 @@
                           "value": "provided_gas",
                           "span": {
                             "dummy": false,
-                            "start": 475,
-                            "end": 487
+                            "start": 477,
+                            "end": 489
                           }
                         }
                       },
@@ -94,15 +94,15 @@
                           "value": "fees",
                           "span": {
                             "dummy": false,
-                            "start": 490,
-                            "end": 494
+                            "start": 492,
+                            "end": 496
                           }
                         }
                       },
                       "span": {
                         "dummy": false,
-                        "start": 488,
-                        "end": 489
+                        "start": 490,
+                        "end": 491
                       }
                     }
                   },
@@ -113,8 +113,8 @@
                         "value": "MyToken",
                         "span": {
                           "dummy": false,
-                          "start": 497,
-                          "end": 504
+                          "start": 499,
+                          "end": 506
                         }
                       },
                       "amount": {
@@ -122,22 +122,22 @@
                           "value": "quantity",
                           "span": {
                             "dummy": false,
-                            "start": 505,
-                            "end": 513
+                            "start": 507,
+                            "end": 515
                           }
                         }
                       },
                       "span": {
                         "dummy": false,
-                        "start": 497,
-                        "end": 514
+                        "start": 499,
+                        "end": 516
                       }
                     }
                   },
                   "span": {
                     "dummy": false,
-                    "start": 495,
-                    "end": 496
+                    "start": 497,
+                    "end": 498
                   }
                 }
               }
@@ -145,8 +145,8 @@
           ],
           "span": {
             "dummy": false,
-            "start": 427,
-            "end": 521
+            "start": 429,
+            "end": 523
           }
         }
       ],
@@ -162,8 +162,8 @@
                     "value": "MyToken",
                     "span": {
                       "dummy": false,
-                      "start": 365,
-                      "end": 372
+                      "start": 367,
+                      "end": 374
                     }
                   },
                   "amount": {
@@ -171,15 +171,15 @@
                       "value": "quantity",
                       "span": {
                         "dummy": false,
-                        "start": 373,
-                        "end": 381
+                        "start": 375,
+                        "end": 383
                       }
                     }
                   },
                   "span": {
                     "dummy": false,
-                    "start": 365,
-                    "end": 382
+                    "start": 367,
+                    "end": 384
                   }
                 }
               }
@@ -190,8 +190,8 @@
                   "value": "password",
                   "span": {
                     "dummy": false,
-                    "start": 402,
-                    "end": 410
+                    "start": 404,
+                    "end": 412
                   }
                 }
               }
@@ -199,16 +199,16 @@
           ],
           "span": {
             "dummy": false,
-            "start": 342,
-            "end": 417
+            "start": 344,
+            "end": 419
           }
         }
       ],
       "adhoc": [],
       "span": {
         "dummy": false,
-        "start": 188,
-        "end": 523
+        "start": 190,
+        "end": 525
       },
       "collateral": [],
       "metadata": null
@@ -219,20 +219,29 @@
     {
       "name": "MyToken",
       "policy": {
-        "value": "ef7a1cebb2dc7de884ddf82f8fcbc91fe9750dcd8c12ec7643a99bbe",
-        "span": {
-          "dummy": false,
-          "start": 101,
-          "end": 159
+        "HexString": {
+          "value": "ef7a1cebb2dc7de884ddf82f8fcbc91fe9750dcd8c12ec7643a99bbe",
+          "span": {
+            "dummy": false,
+            "start": 101,
+            "end": 159
+          }
         }
       },
       "asset_name": {
-        "Ascii": "MYTOKEN"
+        "String": {
+          "value": "MYTOKEN",
+          "span": {
+            "dummy": false,
+            "start": 160,
+            "end": 169
+          }
+        }
       },
       "span": {
         "dummy": false,
         "start": 85,
-        "end": 168
+        "end": 170
       }
     }
   ],
@@ -241,8 +250,8 @@
       "name": "Requester",
       "span": {
         "dummy": false,
-        "start": 170,
-        "end": 186
+        "start": 172,
+        "end": 188
       }
     }
   ],
@@ -269,6 +278,6 @@
   "span": {
     "dummy": false,
     "start": 0,
-    "end": 525
+    "end": 527
   }
 }

--- a/examples/faucet.ast
+++ b/examples/faucet.ast
@@ -226,7 +226,9 @@
           "end": 159
         }
       },
-      "asset_name": "MYTOKEN",
+      "asset_name": {
+        "Ascii": "MYTOKEN"
+      },
       "span": {
         "dummy": false,
         "start": 85,

--- a/examples/faucet.claim_with_password.tir
+++ b/examples/faucet.claim_with_password.tir
@@ -75,15 +75,7 @@
                   ]
                 },
                 "asset_name": {
-                  "Bytes": [
-                    77,
-                    89,
-                    84,
-                    79,
-                    75,
-                    69,
-                    78
-                  ]
+                  "String": "MYTOKEN"
                 },
                 "amount": {
                   "EvalParameter": [
@@ -138,15 +130,7 @@
               ]
             },
             "asset_name": {
-              "Bytes": [
-                77,
-                89,
-                84,
-                79,
-                75,
-                69,
-                78
-              ]
+              "String": "MYTOKEN"
             },
             "amount": {
               "EvalParameter": [

--- a/examples/faucet.tx3
+++ b/examples/faucet.tx3
@@ -1,6 +1,6 @@
 policy PasswordPolicy = 0xef7a1cebb2dc7de884ddf82f8fcbc91fe9750dcd8c12ec7643a99bbe;
 
-asset MyToken = 0xef7a1cebb2dc7de884ddf82f8fcbc91fe9750dcd8c12ec7643a99bbe.MYTOKEN;
+asset MyToken = 0xef7a1cebb2dc7de884ddf82f8fcbc91fe9750dcd8c12ec7643a99bbe."MYTOKEN";
 
 party Requester;
 

--- a/examples/lang_tour.ast
+++ b/examples/lang_tour.ast
@@ -766,7 +766,9 @@
           "end": 299
         }
       },
-      "asset_name": "MYTOKEN",
+      "asset_name": {
+        "Ascii": "MYTOKEN"
+      },
       "span": {
         "dummy": false,
         "start": 267,

--- a/examples/lang_tour.ast
+++ b/examples/lang_tour.ast
@@ -19,8 +19,8 @@
         ],
         "span": {
           "dummy": false,
-          "start": 422,
-          "end": 486
+          "start": 424,
+          "end": 488
         }
       },
       "references": [],
@@ -35,8 +35,8 @@
                   "value": "MyParty",
                   "span": {
                     "dummy": false,
-                    "start": 522,
-                    "end": 529
+                    "start": 524,
+                    "end": 531
                   }
                 }
               }
@@ -60,8 +60,8 @@
                     "value": "Ada",
                     "span": {
                       "dummy": false,
-                      "start": 579,
-                      "end": 582
+                      "start": 581,
+                      "end": 584
                     }
                   },
                   "amount": {
@@ -69,15 +69,15 @@
                       "value": "quantity",
                       "span": {
                         "dummy": false,
-                        "start": 583,
-                        "end": 591
+                        "start": 585,
+                        "end": 593
                       }
                     }
                   },
                   "span": {
                     "dummy": false,
-                    "start": 579,
-                    "end": 592
+                    "start": 581,
+                    "end": 594
                   }
                 }
               }
@@ -89,8 +89,8 @@
                     "value": "MyVariant",
                     "span": {
                       "dummy": false,
-                      "start": 612,
-                      "end": 621
+                      "start": 614,
+                      "end": 623
                     }
                   },
                   "case": {
@@ -98,8 +98,8 @@
                       "value": "Case1",
                       "span": {
                         "dummy": false,
-                        "start": 623,
-                        "end": 628
+                        "start": 625,
+                        "end": 630
                       }
                     },
                     "fields": [
@@ -108,8 +108,8 @@
                           "value": "field1",
                           "span": {
                             "dummy": false,
-                            "start": 643,
-                            "end": 649
+                            "start": 645,
+                            "end": 651
                           }
                         },
                         "value": {
@@ -117,8 +117,8 @@
                         },
                         "span": {
                           "dummy": false,
-                          "start": 643,
-                          "end": 653
+                          "start": 645,
+                          "end": 655
                         }
                       },
                       {
@@ -126,8 +126,8 @@
                           "value": "field2",
                           "span": {
                             "dummy": false,
-                            "start": 667,
-                            "end": 673
+                            "start": 669,
+                            "end": 675
                           }
                         },
                         "value": {
@@ -135,15 +135,15 @@
                             "value": "AFAFAF",
                             "span": {
                               "dummy": false,
-                              "start": 675,
-                              "end": 683
+                              "start": 677,
+                              "end": 685
                             }
                           }
                         },
                         "span": {
                           "dummy": false,
-                          "start": 667,
-                          "end": 683
+                          "start": 669,
+                          "end": 685
                         }
                       },
                       {
@@ -151,8 +151,8 @@
                           "value": "field3",
                           "span": {
                             "dummy": false,
-                            "start": 697,
-                            "end": 703
+                            "start": 699,
+                            "end": 705
                           }
                         },
                         "value": {
@@ -160,29 +160,29 @@
                             "value": "quantity",
                             "span": {
                               "dummy": false,
-                              "start": 705,
-                              "end": 713
+                              "start": 707,
+                              "end": 715
                             }
                           }
                         },
                         "span": {
                           "dummy": false,
-                          "start": 697,
-                          "end": 713
+                          "start": 699,
+                          "end": 715
                         }
                       }
                     ],
                     "spread": null,
                     "span": {
                       "dummy": false,
-                      "start": 621,
-                      "end": 724
+                      "start": 623,
+                      "end": 726
                     }
                   },
                   "span": {
                     "dummy": false,
-                    "start": 612,
-                    "end": 724
+                    "start": 614,
+                    "end": 726
                   }
                 }
               }
@@ -190,8 +190,8 @@
           ],
           "span": {
             "dummy": false,
-            "start": 493,
-            "end": 731
+            "start": 495,
+            "end": 733
           }
         }
       ],
@@ -205,8 +205,8 @@
                   "value": "MyParty",
                   "span": {
                     "dummy": false,
-                    "start": 931,
-                    "end": 938
+                    "start": 933,
+                    "end": 940
                   }
                 }
               }
@@ -218,8 +218,8 @@
                     "value": "MyRecord",
                     "span": {
                       "dummy": false,
-                      "start": 955,
-                      "end": 963
+                      "start": 957,
+                      "end": 965
                     }
                   },
                   "case": {
@@ -237,8 +237,8 @@
                           "value": "field1",
                           "span": {
                             "dummy": false,
-                            "start": 978,
-                            "end": 984
+                            "start": 980,
+                            "end": 986
                           }
                         },
                         "value": {
@@ -246,15 +246,15 @@
                             "value": "quantity",
                             "span": {
                               "dummy": false,
-                              "start": 986,
-                              "end": 994
+                              "start": 988,
+                              "end": 996
                             }
                           }
                         },
                         "span": {
                           "dummy": false,
-                          "start": 978,
-                          "end": 994
+                          "start": 980,
+                          "end": 996
                         }
                       },
                       {
@@ -262,8 +262,8 @@
                           "value": "field2",
                           "span": {
                             "dummy": false,
-                            "start": 1008,
-                            "end": 1014
+                            "start": 1010,
+                            "end": 1016
                           }
                         },
                         "value": {
@@ -271,8 +271,8 @@
                         },
                         "span": {
                           "dummy": false,
-                          "start": 1008,
-                          "end": 1018
+                          "start": 1010,
+                          "end": 1020
                         }
                       },
                       {
@@ -280,8 +280,8 @@
                           "value": "field4",
                           "span": {
                             "dummy": false,
-                            "start": 1032,
-                            "end": 1038
+                            "start": 1034,
+                            "end": 1040
                           }
                         },
                         "value": {
@@ -302,8 +302,8 @@
                                     "value": "source",
                                     "span": {
                                       "dummy": false,
-                                      "start": 1050,
-                                      "end": 1056
+                                      "start": 1052,
+                                      "end": 1058
                                     }
                                   },
                                   "path": [
@@ -311,30 +311,30 @@
                                       "value": "field1",
                                       "span": {
                                         "dummy": false,
-                                        "start": 1057,
-                                        "end": 1063
+                                        "start": 1059,
+                                        "end": 1065
                                       }
                                     }
                                   ],
                                   "span": {
                                     "dummy": false,
-                                    "start": 1050,
-                                    "end": 1063
+                                    "start": 1052,
+                                    "end": 1065
                                   }
                                 }
                               }
                             ],
                             "span": {
                               "dummy": false,
-                              "start": 1040,
-                              "end": 1064
+                              "start": 1042,
+                              "end": 1066
                             }
                           }
                         },
                         "span": {
                           "dummy": false,
-                          "start": 1032,
-                          "end": 1064
+                          "start": 1034,
+                          "end": 1066
                         }
                       }
                     ],
@@ -343,21 +343,21 @@
                         "value": "source",
                         "span": {
                           "dummy": false,
-                          "start": 1081,
-                          "end": 1087
+                          "start": 1083,
+                          "end": 1089
                         }
                       }
                     },
                     "span": {
                       "dummy": false,
-                      "start": 964,
-                      "end": 1097
+                      "start": 966,
+                      "end": 1099
                     }
                   },
                   "span": {
                     "dummy": false,
-                    "start": 955,
-                    "end": 1097
+                    "start": 957,
+                    "end": 1099
                   }
                 }
               }
@@ -373,8 +373,8 @@
                             "value": "source",
                             "span": {
                               "dummy": false,
-                              "start": 1124,
-                              "end": 1130
+                              "start": 1126,
+                              "end": 1132
                             }
                           },
                           "path": [
@@ -382,15 +382,15 @@
                               "value": "field3",
                               "span": {
                                 "dummy": false,
-                                "start": 1131,
-                                "end": 1137
+                                "start": 1133,
+                                "end": 1139
                               }
                             }
                           ],
                           "span": {
                             "dummy": false,
-                            "start": 1124,
-                            "end": 1137
+                            "start": 1126,
+                            "end": 1139
                           }
                         }
                       },
@@ -400,8 +400,8 @@
                             "value": "source",
                             "span": {
                               "dummy": false,
-                              "start": 1139,
-                              "end": 1145
+                              "start": 1141,
+                              "end": 1147
                             }
                           },
                           "path": [
@@ -409,15 +409,15 @@
                               "value": "field2",
                               "span": {
                                 "dummy": false,
-                                "start": 1146,
-                                "end": 1152
+                                "start": 1148,
+                                "end": 1154
                               }
                             }
                           ],
                           "span": {
                             "dummy": false,
-                            "start": 1139,
-                            "end": 1152
+                            "start": 1141,
+                            "end": 1154
                           }
                         }
                       },
@@ -427,8 +427,8 @@
                             "value": "source",
                             "span": {
                               "dummy": false,
-                              "start": 1154,
-                              "end": 1160
+                              "start": 1156,
+                              "end": 1162
                             }
                           },
                           "path": [
@@ -436,22 +436,22 @@
                               "value": "field1",
                               "span": {
                                 "dummy": false,
-                                "start": 1161,
-                                "end": 1167
+                                "start": 1163,
+                                "end": 1169
                               }
                             }
                           ],
                           "span": {
                             "dummy": false,
-                            "start": 1154,
-                            "end": 1167
+                            "start": 1156,
+                            "end": 1169
                           }
                         }
                       },
                       "span": {
                         "dummy": false,
-                        "start": 1115,
-                        "end": 1168
+                        "start": 1117,
+                        "end": 1170
                       }
                     }
                   },
@@ -462,8 +462,8 @@
                         "value": "Ada",
                         "span": {
                           "dummy": false,
-                          "start": 1171,
-                          "end": 1174
+                          "start": 1173,
+                          "end": 1176
                         }
                       },
                       "amount": {
@@ -471,15 +471,15 @@
                       },
                       "span": {
                         "dummy": false,
-                        "start": 1171,
-                        "end": 1178
+                        "start": 1173,
+                        "end": 1180
                       }
                     }
                   },
                   "span": {
                     "dummy": false,
-                    "start": 1169,
-                    "end": 1170
+                    "start": 1171,
+                    "end": 1172
                   }
                 }
               }
@@ -487,8 +487,8 @@
           ],
           "span": {
             "dummy": false,
-            "start": 910,
-            "end": 1185
+            "start": 912,
+            "end": 1187
           }
         }
       ],
@@ -505,8 +505,8 @@
                 "value": "validUntil",
                 "span": {
                   "dummy": false,
-                  "start": 1257,
-                  "end": 1267
+                  "start": 1259,
+                  "end": 1269
                 }
               }
             }
@@ -514,8 +514,8 @@
         ],
         "span": {
           "dummy": false,
-          "start": 1191,
-          "end": 1274
+          "start": 1193,
+          "end": 1276
         }
       },
       "burn": null,
@@ -529,8 +529,8 @@
                     "value": "StaticAsset",
                     "span": {
                       "dummy": false,
-                      "start": 760,
-                      "end": 771
+                      "start": 762,
+                      "end": 773
                     }
                   },
                   "amount": {
@@ -538,8 +538,8 @@
                   },
                   "span": {
                     "dummy": false,
-                    "start": 760,
-                    "end": 776
+                    "start": 762,
+                    "end": 778
                   }
                 }
               }
@@ -550,8 +550,8 @@
           ],
           "span": {
             "dummy": false,
-            "start": 737,
-            "end": 805
+            "start": 739,
+            "end": 807
           }
         },
         {
@@ -564,8 +564,8 @@
                       "value": "AB11223344",
                       "span": {
                         "dummy": false,
-                        "start": 843,
-                        "end": 855
+                        "start": 845,
+                        "end": 857
                       }
                     }
                   },
@@ -574,8 +574,8 @@
                       "value": "OTHER_TOKEN",
                       "span": {
                         "dummy": false,
-                        "start": 857,
-                        "end": 870
+                        "start": 859,
+                        "end": 872
                       }
                     }
                   },
@@ -584,8 +584,8 @@
                   },
                   "span": {
                     "dummy": false,
-                    "start": 834,
-                    "end": 875
+                    "start": 836,
+                    "end": 877
                   }
                 }
               }
@@ -596,16 +596,16 @@
           ],
           "span": {
             "dummy": false,
-            "start": 811,
-            "end": 904
+            "start": 813,
+            "end": 906
           }
         }
       ],
       "adhoc": [],
       "span": {
         "dummy": false,
-        "start": 414,
-        "end": 1319
+        "start": 416,
+        "end": 1321
       },
       "collateral": [],
       "metadata": {
@@ -619,22 +619,22 @@
                 "value": "metadata",
                 "span": {
                   "dummy": false,
-                  "start": 1302,
-                  "end": 1310
+                  "start": 1304,
+                  "end": 1312
                 }
               }
             },
             "span": {
               "dummy": false,
-              "start": 1299,
-              "end": 1310
+              "start": 1301,
+              "end": 1312
             }
           }
         ],
         "span": {
           "dummy": false,
-          "start": 1280,
-          "end": 1317
+          "start": 1282,
+          "end": 1319
         }
       }
     }
@@ -759,20 +759,29 @@
     {
       "name": "StaticAsset",
       "policy": {
-        "value": "ABCDEF1234",
-        "span": {
-          "dummy": false,
-          "start": 287,
-          "end": 299
+        "HexString": {
+          "value": "ABCDEF1234",
+          "span": {
+            "dummy": false,
+            "start": 287,
+            "end": 299
+          }
         }
       },
       "asset_name": {
-        "Ascii": "MYTOKEN"
+        "String": {
+          "value": "MYTOKEN",
+          "span": {
+            "dummy": false,
+            "start": 300,
+            "end": 309
+          }
+        }
       },
       "span": {
         "dummy": false,
         "start": 267,
-        "end": 308
+        "end": 310
       }
     }
   ],
@@ -816,8 +825,8 @@
                   "value": "ABCDEF1234",
                   "span": {
                     "dummy": false,
-                    "start": 348,
-                    "end": 360
+                    "start": 350,
+                    "end": 362
                   }
                 }
               }
@@ -828,8 +837,8 @@
                   "value": "ABCDEF1234",
                   "span": {
                     "dummy": false,
-                    "start": 374,
-                    "end": 386
+                    "start": 376,
+                    "end": 388
                   }
                 }
               }
@@ -840,8 +849,8 @@
                   "value": "ABCDEF1234",
                   "span": {
                     "dummy": false,
-                    "start": 397,
-                    "end": 409
+                    "start": 399,
+                    "end": 411
                   }
                 }
               }
@@ -849,21 +858,21 @@
           ],
           "span": {
             "dummy": false,
-            "start": 336,
-            "end": 412
+            "start": 338,
+            "end": 414
           }
         }
       },
       "span": {
         "dummy": false,
-        "start": 310,
-        "end": 412
+        "start": 312,
+        "end": 414
       }
     }
   ],
   "span": {
     "dummy": false,
     "start": 0,
-    "end": 1320
+    "end": 1322
   }
 }

--- a/examples/lang_tour.my_tx.tir
+++ b/examples/lang_tour.my_tx.tir
@@ -174,15 +174,7 @@
               ]
             },
             "asset_name": {
-              "Bytes": [
-                77,
-                89,
-                84,
-                79,
-                75,
-                69,
-                78
-              ]
+              "String": "MYTOKEN"
             },
             "amount": {
               "Number": 100

--- a/examples/lang_tour.tx3
+++ b/examples/lang_tour.tx3
@@ -18,7 +18,7 @@ type MyVariant {
 
 policy OnlyHashPolicy = 0xABCDEF1234;
 
-asset StaticAsset = 0xABCDEF1234.MYTOKEN;
+asset StaticAsset = 0xABCDEF1234."MYTOKEN";
 
 policy FullyDefinedPolicy {
     hash: 0xABCDEF1234,

--- a/examples/order-book.tx3
+++ b/examples/order-book.tx3
@@ -5,8 +5,8 @@ policy OrderBook {
   script: 0xfacd82a32c6692dd60b6b930a86569d4f7a5558684bebc7b2f34259f0dc20b07#0,
 }
 
-asset ControlToken = 0x39c520d0627aafa728f7e4dd10142b77c257813c36f57e2cb88f72a5.CONTROL;
-asset Bid = 0x39c520d0627aafa728f7e4dd10142b77c257813c36f57e2cb88f72a5.BID;
+asset ControlToken = 0x39c520d0627aafa728f7e4dd10142b77c257813c36f57e2cb88f72a5."CONTROL";
+asset Bid = 0x39c520d0627aafa728f7e4dd10142b77c257813c36f57e2cb88f72a5."BID";
 
 type AssetClass {
   policy: Bytes,

--- a/examples/semantic_errors.tx3
+++ b/examples/semantic_errors.tx3
@@ -1,0 +1,8 @@
+asset BadPolicyType = 1234."ABC";
+asset BadAssetNameType = 0xABC.333;
+
+tx tx1() {
+    output {
+        to: missing_symbol,
+    }
+}

--- a/examples/swap_static.tx3
+++ b/examples/swap_static.tx3
@@ -1,5 +1,5 @@
-asset A = 0xabc123.A;
-asset B = 0xabc123.B;
+asset A = 0xabc123."A";
+asset B = 0xabc123."B";
 
 type PoolState {
     pair_a: Int,


### PR DESCRIPTION
Add support on asset definition for hex and string on names

```tx3
asset MyTokenHex = 0x12345678.0xABC;
asset MyTokenAscii = 0x12345678.MY_TOKEN;
asset MyTokenString = 0x12345678."MY TOKEN";
```
