### PR TITLE
fix: Correctly supports null auxiliary_data field

### DIFF
--- a/crates/tx3-cardano/src/compile/mod.rs
+++ b/crates/tx3-cardano/src/compile/mod.rs
@@ -372,19 +372,17 @@ fn compile_auxiliary_data(tx: &ir::Tx) -> Result<Option<primitives::AuxiliaryDat
     match metadata_kv {
         Ok(key_values) => {
             let metadata_tree = pallas::ledger::primitives::alonzo::Metadata::from_iter(key_values);
-            let metadata = if metadata_tree.is_empty() {
-                None
+            if metadata_tree.is_empty() {
+                Ok(None)
             } else {
-                Some(metadata_tree)
-            };
-
-            Ok(Some(primitives::AuxiliaryData::PostAlonzo(
-                pallas::ledger::primitives::alonzo::PostAlonzoAuxiliaryData {
-                    metadata,
-                    native_scripts: None,
-                    plutus_scripts: None,
-                },
-            )))
+                Ok(Some(primitives::AuxiliaryData::PostAlonzo(
+                    pallas::ledger::primitives::alonzo::PostAlonzoAuxiliaryData {
+                        metadata: Some(metadata_tree),
+                        native_scripts: None,
+                        plutus_scripts: None,
+                    },
+                )))
+            }
         }
         Err(err) => Err(err),
     }


### PR DESCRIPTION
When no metadata block is provided, auxiliary_data field of the transaction should be set to null and the auxiliary_data_hash field should not be included.