### PR TITLE
feat(analysis): integrate ropey for source code handling in semantic …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,6 +1727,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ropey"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93411e420bcd1a75ddd1dc3caf18c23155eda2c090631a85af21ba19e97093b5"
+dependencies = [
+ "smallvec",
+ "str_indices",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,6 +1996,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "str_indices"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
 
 [[package]]
 name = "strsim"
@@ -2408,6 +2424,7 @@ dependencies = [
  "paste",
  "pest",
  "pest_derive",
+ "ropey",
  "serde",
  "serde_json",
  "thiserror 2.0.11",

--- a/crates/tx3-lang/Cargo.toml
+++ b/crates/tx3-lang/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1.0.217", features = ["derive"] }
 thiserror = "2.0.11"
 hex = "0.4.3"
 bincode = "2.0.1"
+ropey = "1.6.1"
 
 
 [dev-dependencies]

--- a/crates/tx3-lang/src/ast.rs
+++ b/crates/tx3-lang/src/ast.rs
@@ -76,6 +76,10 @@ impl Span {
             end,
         }
     }
+
+    pub fn is_dummy(&self) -> bool {
+        self.dummy || (self.start == 0 && self.end == 0)
+    }
 }
 
 impl Symbol {
@@ -169,6 +173,9 @@ pub struct Program {
     // analysis
     #[serde(skip)]
     pub(crate) scope: Option<Rc<Scope>>,
+
+    #[serde(skip)]
+    pub source_code: Option<ropey::Rope>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/tx3-lang/src/cardano.rs
+++ b/crates/tx3-lang/src/cardano.rs
@@ -4,7 +4,7 @@ use pest::iterators::Pair;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    analyzing::{Analyzable, AnalyzeReport},
+    analyzing::{Analyzable, AnalyzeReport, AnalyzeContext},
     ast::{DataExpr, Scope, Span},
     ir,
     lowering::IntoLower,
@@ -38,9 +38,9 @@ impl AstNode for VoteDelegationCertificate {
 }
 
 impl Analyzable for VoteDelegationCertificate {
-    fn analyze(&mut self, parent: Option<Rc<Scope>>) -> AnalyzeReport {
-        let drep = self.drep.analyze(parent.clone());
-        let stake = self.stake.analyze(parent.clone());
+    fn analyze(&mut self, parent: Option<Rc<Scope>>, ctx: &AnalyzeContext) -> AnalyzeReport {
+        let drep = self.drep.analyze(parent.clone(), ctx);
+        let stake = self.stake.analyze(parent.clone(), ctx);
 
         drep + stake
     }
@@ -91,9 +91,9 @@ impl AstNode for StakeDelegationCertificate {
 }
 
 impl Analyzable for StakeDelegationCertificate {
-    fn analyze(&mut self, parent: Option<Rc<Scope>>) -> AnalyzeReport {
-        let pool = self.pool.analyze(parent.clone());
-        let stake = self.stake.analyze(parent.clone());
+    fn analyze(&mut self, parent: Option<Rc<Scope>>, ctx: &AnalyzeContext) -> AnalyzeReport {
+        let pool = self.pool.analyze(parent.clone(), ctx);
+        let stake = self.stake.analyze(parent.clone(), ctx);
 
         pool + stake
     }
@@ -129,9 +129,9 @@ impl AstNode for CardanoBlock {
 }
 
 impl Analyzable for CardanoBlock {
-    fn analyze(&mut self, parent: Option<Rc<Scope>>) -> AnalyzeReport {
+    fn analyze(&mut self, parent: Option<Rc<Scope>>, ctx: &AnalyzeContext) -> AnalyzeReport {
         match self {
-            CardanoBlock::VoteDelegationCertificate(x) => x.analyze(parent),
+            CardanoBlock::VoteDelegationCertificate(x) => x.analyze(parent, ctx),
             _ => todo!(),
         }
     }

--- a/crates/tx3-lang/src/parsing.rs
+++ b/crates/tx3-lang/src/parsing.rs
@@ -86,6 +86,7 @@ impl AstNode for Program {
             policies: Vec::new(),
             scope: None,
             span,
+            source_code: None,
         };
 
         for pair in inner {
@@ -1383,7 +1384,11 @@ impl AstNode for ChainSpecificBlock {
 /// ```
 pub fn parse_string(input: &str) -> Result<Program, Error> {
     let pairs = Tx3Grammar::parse(Rule::program, input)?;
-    Program::parse(pairs.into_iter().next().unwrap())
+    let mut program = Program::parse(pairs.into_iter().next().unwrap())?;
+
+    program.source_code = Some(ropey::Rope::from_str(input));
+
+    Ok(program)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
…analysis

Example:
```
➜ trix check
Error:   × check failed

Error: tx3::not_in_scope

  × not in scope: Receivers
   ╭─[2:13]
 1 │     output {
 2 │         to: Receivers,
   ·             ─────────
 3 │         amount: Ada(quantity),
   ╰────
```

This solves #142 