### PR TITLE
Fix/utxo ref analyze

### DIFF
--- a/crates/tx3-cardano/src/coercion.rs
+++ b/crates/tx3-cardano/src/coercion.rs
@@ -69,6 +69,13 @@ pub fn expr_into_metadatum(
 pub fn expr_into_utxo_refs(expr: &ir::Expression) -> Result<Vec<tx3_lang::UtxoRef>, Error> {
     match expr {
         ir::Expression::UtxoRefs(x) => Ok(x.clone()),
+        ir::Expression::String(x) => {
+            let (raw_txid, raw_output_ix) = x.split_once("#").expect("Invalid utxo ref");
+            Ok(vec![tx3_lang::UtxoRef {
+                txid: hex::decode(raw_txid).expect("Invalid hex txid"),
+                index: raw_output_ix.parse().expect("Invalid output index"),
+            }])
+        }
         _ => Err(Error::CoerceError(
             format!("{:?}", expr),
             "UtxoRefs".to_string(),

--- a/crates/tx3-cardano/src/compile/mod.rs
+++ b/crates/tx3-cardano/src/compile/mod.rs
@@ -307,6 +307,19 @@ fn compile_collateral(tx: &ir::Tx) -> Option<NonEmptySet<TransactionInput>> {
                     index: index as u64,
                 }])
             }),
+            ir::Expression::String(x) => {
+                let (raw_txid, raw_output_ix) = x.split_once("#").expect("Invalid utxo ref");
+                let transaction_id = primitives::Hash::<32>::from(
+                    hex::decode(raw_txid)
+                        .expect("Invalid hex transaction id")
+                        .as_slice(),
+                );
+                let index = raw_output_ix.parse().expect("Invalid output index");
+                Some(NonEmptySet::from_vec(vec![TransactionInput {
+                    transaction_id,
+                    index,
+                }]))
+            }
             _ => None,
         })
         .flatten()

--- a/crates/tx3-cardano/src/compile/mod.rs
+++ b/crates/tx3-cardano/src/compile/mod.rs
@@ -317,7 +317,7 @@ fn compile_required_signers(tx: &ir::Tx) -> Result<Option<primitives::RequiredSi
     let Some(signers) = &tx.signers else {
         return Ok(primitives::RequiredSigners::from_vec(hashes));
     };
-    
+
     for signer in &signers.signers {
         match signer {
             ir::Expression::String(s) => {
@@ -328,20 +328,20 @@ fn compile_required_signers(tx: &ir::Tx) -> Result<Option<primitives::RequiredSi
                         "Shelley address".to_string(),
                     ));
                 };
-        
+
                 let ShelleyPaymentPart::Key(key) = addr.payment() else {
                     return Err(Error::CoerceError(
                         format!("{:?}", signer),
                         "Key payment credential".to_string(),
                     ));
                 };
-        
+
                 hashes.push(*key);
-            },
+            }
             ir::Expression::Bytes(b) => {
                 let bytes = primitives::Bytes::from(b.clone());
                 hashes.push(primitives::AddrKeyhash::from(bytes.as_slice()));
-            },
+            }
             _ => {
                 return Err(Error::CoerceError(
                     format!("{:?}", signer),
@@ -448,7 +448,10 @@ fn compile_single_spend_redeemer(
     let redeemer = primitives::Redeemer {
         tag: primitives::RedeemerTag::Spend,
         index: index as u32,
-        ex_units: primitives::ExUnits { mem: 0, steps: 0 },
+        ex_units: primitives::ExUnits {
+            mem: 2000000,
+            steps: 2000000000,
+        },
         data: redeemer.try_as_data()?,
     };
 
@@ -515,8 +518,8 @@ fn compile_mint_redeemer(
         tag: primitives::RedeemerTag::Mint,
         index: mint_redeemer_index(compiled_body, policy)?,
         ex_units: primitives::ExUnits {
-            mem: 2000,
-            steps: 200000,
+            mem: 10000000,
+            steps: 2000000000,
         },
         data: red.try_as_data()?,
     };

--- a/crates/tx3-cardano/src/resolve.rs
+++ b/crates/tx3-cardano/src/resolve.rs
@@ -18,7 +18,7 @@ pub trait Ledger {
 }
 
 fn eval_size_fees(tx: &[u8], pparams: &PParams) -> Result<u64, Error> {
-    Ok(tx.len() as u64 * pparams.min_fee_coefficient + pparams.min_fee_constant + 200_000)
+    Ok(tx.len() as u64 * pparams.min_fee_coefficient + pparams.min_fee_constant + 1_200_000)
 }
 
 #[allow(dead_code)]

--- a/crates/tx3-lang/src/applying.rs
+++ b/crates/tx3-lang/src/applying.rs
@@ -1465,6 +1465,8 @@ impl Apply for ir::Tx {
             && self.fees.is_constant()
             && self.metadata.is_constant()
             && self.validity.is_constant()
+            && self.references.is_constant()
+            && self.collateral.is_constant()
             && self.adhoc.iter().all(|x| x.is_constant())
             && self.signers.is_constant()
     }
@@ -1480,11 +1482,12 @@ impl Apply for ir::Tx {
         params.extend(self.signers.params());
         params.extend(self.validity.params());
         params.extend(self.metadata.params());
+        params.extend(self.references.params());
+        params.extend(self.collateral.params());
         params
     }
 
     fn queries(&self) -> BTreeMap<String, ir::InputQuery> {
-        // TODO: analyze if necessary to add ref_inputs
         let mut queries = BTreeMap::new();
         queries.extend(self.inputs.queries());
         queries.extend(self.outputs.queries());
@@ -1494,6 +1497,8 @@ impl Apply for ir::Tx {
         queries.extend(self.signers.queries());
         queries.extend(self.validity.queries());
         queries.extend(self.metadata.queries());
+        queries.extend(self.collateral.queries());
+        queries.extend(self.references.queries());
         queries
     }
 

--- a/crates/tx3-lang/src/lowering.rs
+++ b/crates/tx3-lang/src/lowering.rs
@@ -512,8 +512,8 @@ impl IntoLower for ast::ValidityBlock {
 
     fn into_lower(&self) -> Result<Self::Output, Error> {
         Ok(ir::Validity {
-            since: self.find("valid_since").into_lower()?,
-            until: self.find("valid_until").into_lower()?,
+            since: self.find("since_slot").into_lower()?,
+            until: self.find("until_slot").into_lower()?,
         })
     }
 }
@@ -661,11 +661,7 @@ pub fn lower_tx(ast: &ast::TxDef) -> Result<ir::Tx, Error> {
             .iter()
             .map(|x| x.into_lower())
             .collect::<Result<Vec<_>, _>>()?,
-        signers: ast
-            .signers
-            .as_ref()
-            .map(|x| x.into_lower())
-            .transpose()?,
+        signers: ast.signers.as_ref().map(|x| x.into_lower()).transpose()?,
         metadata: ast
             .metadata
             .as_ref()

--- a/crates/tx3-lang/src/parsing.rs
+++ b/crates/tx3-lang/src/parsing.rs
@@ -301,7 +301,7 @@ impl AstNode for CollateralBlockField {
             }
             Rule::input_block_ref => {
                 let pair = pair.into_inner().next().unwrap();
-                let x = CollateralBlockField::Ref(DataExpr::UtxoRef(UtxoRef::parse(pair)?));
+                let x = CollateralBlockField::Ref(DataExpr::parse(pair)?);
                 Ok(x)
             }
             x => unreachable!("Unexpected rule in collateral_block: {:?}", x),

--- a/examples/lang_tour.my_tx.tir
+++ b/examples/lang_tour.my_tx.tir
@@ -156,8 +156,15 @@
     }
   ],
   "validity": {
-    "since": null,
-    "until": null
+    "since": {
+      "Number": 1735700400000
+    },
+    "until": {
+      "EvalParameter": [
+        "validuntil",
+        "Int"
+      ]
+    }
   },
   "mints": [
     {


### PR DESCRIPTION
This PR solves a couple of issues we ran into:
- validity range wasn't being lowered after the fields were renamed
- if you pass an utxoref from typescript (it requires a string). you can pass it as "0123123#1" and it will be coerced on tx compilation
- both collateral and reference blocks were not part of the analyze phase of the transaction (the applying phase was a bit incomplete as well)
- increased hardcoded execution units and fees in order for it to allow things (it was [0, 0] on single spend
- `CollateralBlockField` restricted too much the type of data expression it could parse