### PR TITLE
feat: resolve input datum for an output

### DIFF
--- a/crates/tx3-cardano/src/ledgers/mock.rs
+++ b/crates/tx3-cardano/src/ledgers/mock.rs
@@ -30,7 +30,10 @@ static COST_MODEL_PLUTUS_V2: [i64; 175] = [
     32, 24623, 32, 43053543, 10, 53384111, 14333, 10, 43574283, 26308, 10,
 ];
 
-pub struct MockLedger;
+#[derive(Debug, Default)]
+pub struct MockLedger {
+    pub default_datum: Option<tx3_lang::ir::Expression>,
+}
 
 impl Ledger for MockLedger {
     async fn get_pparams(&self) -> Result<PParams, Error> {
@@ -56,7 +59,7 @@ impl Ledger for MockLedger {
             index: 0,
         },
         address: pallas::ledger::addresses::Address::from_bech32("addr1qx0rs5qrvx9qkndwu0w88t0xghgy3f53ha76kpx8uf496m9rn2ursdm3r0fgf5pmm4lpufshl8lquk5yykg4pd00hp6quf2hh2").unwrap().to_vec(),
-        datum: None,
+        datum: self.default_datum.clone(),
         assets: vec![tx3_lang::ir::AssetExpr {
             policy: tx3_lang::ir::Expression::None,
             asset_name: tx3_lang::ir::Expression::None,

--- a/crates/tx3-cardano/src/resolve.rs
+++ b/crates/tx3-cardano/src/resolve.rs
@@ -134,7 +134,7 @@ mod tests {
             .apply()
             .unwrap();
 
-        let tx = resolve_tx(tx, MockLedger, 3).await.unwrap();
+        let tx = resolve_tx(tx, MockLedger::default(), 3).await.unwrap();
 
         println!("{}", hex::encode(tx.payload));
         println!("{}", tx.fee);
@@ -153,7 +153,7 @@ mod tests {
             .apply()
             .unwrap();
 
-        let tx = resolve_tx(tx, MockLedger, 3).await.unwrap();
+        let tx = resolve_tx(tx, MockLedger::default(), 3).await.unwrap();
 
         println!("{}", hex::encode(tx.payload));
         println!("{}", tx.fee);
@@ -180,7 +180,7 @@ mod tests {
         dbg!(&tx.find_params());
         dbg!(&tx.find_queries());
 
-        let tx = resolve_tx(tx, MockLedger, 3).await.unwrap();
+        let tx = resolve_tx(tx, MockLedger::default(), 3).await.unwrap();
 
         println!("{}", hex::encode(tx.payload));
         println!("{}", tx.fee);
@@ -204,7 +204,41 @@ mod tests {
 
         let tx = tx.apply().unwrap();
 
-        let tx = resolve_tx(tx, MockLedger, 3).await.unwrap();
+        let tx = resolve_tx(tx, MockLedger::default(), 3).await.unwrap();
+
+        println!("{}", hex::encode(&tx.payload));
+        println!("{}", tx.fee);
+    }
+
+    #[tokio::test]
+    async fn asteria_datum_test() {
+        let protocol = load_protocol("asteria_datum");
+
+        let tx = protocol
+            .new_tx("testDatum")
+            .unwrap()
+            .apply()
+            .unwrap();
+
+        dbg!(&tx.find_params());
+
+        let tx = tx.apply().unwrap();
+
+        let tx = resolve_tx(
+            tx,
+            MockLedger {
+                default_datum: Some(tx3_lang::ir::Expression::Struct(tx3_lang::ir::StructExpr {
+                    constructor: 0,
+                    fields: vec![
+                        tx3_lang::ir::Expression::Number(13),
+                        tx3_lang::ir::Expression::Bytes(b"abc".to_vec()),
+                    ],
+                })),
+            },
+            3,
+        )
+        .await
+        .unwrap();
 
         println!("{}", hex::encode(&tx.payload));
         println!("{}", tx.fee);

--- a/crates/tx3-lang/src/lowering.rs
+++ b/crates/tx3-lang/src/lowering.rs
@@ -812,4 +812,6 @@ mod tests {
     test_lowering!(vesting);
 
     test_lowering!(faucet);
+
+    test_lowering!(asteria_datum);
 }

--- a/crates/tx3-lang/src/parsing.rs
+++ b/crates/tx3-lang/src/parsing.rs
@@ -2121,4 +2121,6 @@ mod tests {
     test_parsing!(disordered);
 
     test_parsing!(withdraw);
+
+    test_parsing!(asteria_datum);
 }

--- a/examples/asteria_datum.ast
+++ b/examples/asteria_datum.ast
@@ -1,0 +1,333 @@
+{
+  "txs": [
+    {
+      "name": "testDatum",
+      "parameters": {
+        "parameters": [],
+        "span": {
+          "dummy": false,
+          "start": 229,
+          "end": 231
+        }
+      },
+      "references": [],
+      "inputs": [
+        {
+          "name": "asteria",
+          "is_many": false,
+          "fields": [
+            {
+              "From": {
+                "String": {
+                  "value": "addr_test1wqdsuy97njefz53rkhd4v6a2kuqk0md5mrn996ygwekrdyq369wjg",
+                  "span": {
+                    "dummy": false,
+                    "start": 296,
+                    "end": 361
+                  }
+                }
+              }
+            },
+            {
+              "MinAmount": {
+                "StaticAssetConstructor": {
+                  "type": {
+                    "value": "AdminToken",
+                    "span": {
+                      "dummy": false,
+                      "start": 383,
+                      "end": 393
+                    }
+                  },
+                  "amount": {
+                    "Number": 1
+                  },
+                  "span": {
+                    "dummy": false,
+                    "start": 383,
+                    "end": 396
+                  }
+                }
+              }
+            },
+            {
+              "DatumIs": {
+                "Custom": {
+                  "value": "AsteriaDatum",
+                  "span": {
+                    "dummy": true,
+                    "start": 0,
+                    "end": 0
+                  }
+                }
+              }
+            }
+          ],
+          "span": {
+            "dummy": false,
+            "start": 238,
+            "end": 435
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": null,
+          "fields": [
+            {
+              "To": {
+                "String": {
+                  "value": "addr_test1wqdsuy97njefz53rkhd4v6a2kuqk0md5mrn996ygwekrdyq369wjg",
+                  "span": {
+                    "dummy": false,
+                    "start": 522,
+                    "end": 587
+                  }
+                }
+              }
+            },
+            {
+              "Amount": {
+                "Identifier": {
+                  "value": "asteria",
+                  "span": {
+                    "dummy": false,
+                    "start": 605,
+                    "end": 612
+                  }
+                }
+              }
+            },
+            {
+              "Datum": {
+                "StructConstructor": {
+                  "type": {
+                    "value": "AsteriaDatum",
+                    "span": {
+                      "dummy": false,
+                      "start": 629,
+                      "end": 641
+                    }
+                  },
+                  "case": {
+                    "name": {
+                      "value": "Default",
+                      "span": {
+                        "dummy": true,
+                        "start": 0,
+                        "end": 0
+                      }
+                    },
+                    "fields": [
+                      {
+                        "name": {
+                          "value": "ship_counter",
+                          "span": {
+                            "dummy": false,
+                            "start": 656,
+                            "end": 668
+                          }
+                        },
+                        "value": {
+                          "AddOp": {
+                            "lhs": {
+                              "PropertyOp": {
+                                "operand": {
+                                  "Identifier": {
+                                    "value": "asteria",
+                                    "span": {
+                                      "dummy": false,
+                                      "start": 670,
+                                      "end": 677
+                                    }
+                                  }
+                                },
+                                "property": {
+                                  "value": "ship_counter",
+                                  "span": {
+                                    "dummy": false,
+                                    "start": 678,
+                                    "end": 690
+                                  }
+                                },
+                                "span": {
+                                  "dummy": false,
+                                  "start": 677,
+                                  "end": 690
+                                }
+                              }
+                            },
+                            "rhs": {
+                              "Number": 1
+                            },
+                            "span": {
+                              "dummy": false,
+                              "start": 691,
+                              "end": 692
+                            }
+                          }
+                        },
+                        "span": {
+                          "dummy": false,
+                          "start": 656,
+                          "end": 694
+                        }
+                      },
+                      {
+                        "name": {
+                          "value": "shipyard_policy",
+                          "span": {
+                            "dummy": false,
+                            "start": 708,
+                            "end": 723
+                          }
+                        },
+                        "value": {
+                          "PropertyOp": {
+                            "operand": {
+                              "Identifier": {
+                                "value": "asteria",
+                                "span": {
+                                  "dummy": false,
+                                  "start": 725,
+                                  "end": 732
+                                }
+                              }
+                            },
+                            "property": {
+                              "value": "shipyard_policy",
+                              "span": {
+                                "dummy": false,
+                                "start": 733,
+                                "end": 748
+                              }
+                            },
+                            "span": {
+                              "dummy": false,
+                              "start": 732,
+                              "end": 748
+                            }
+                          }
+                        },
+                        "span": {
+                          "dummy": false,
+                          "start": 708,
+                          "end": 748
+                        }
+                      }
+                    ],
+                    "spread": null,
+                    "span": {
+                      "dummy": false,
+                      "start": 642,
+                      "end": 759
+                    }
+                  },
+                  "span": {
+                    "dummy": false,
+                    "start": 629,
+                    "end": 759
+                  }
+                }
+              }
+            }
+          ],
+          "span": {
+            "dummy": false,
+            "start": 473,
+            "end": 766
+          }
+        }
+      ],
+      "validity": null,
+      "burn": null,
+      "mints": [],
+      "signers": null,
+      "adhoc": [],
+      "span": {
+        "dummy": false,
+        "start": 217,
+        "end": 768
+      },
+      "collateral": [],
+      "metadata": null
+    }
+  ],
+  "types": [
+    {
+      "name": "AsteriaDatum",
+      "cases": [
+        {
+          "name": "Default",
+          "fields": [
+            {
+              "name": "ship_counter",
+              "type": "Int",
+              "span": {
+                "dummy": false,
+                "start": 129,
+                "end": 146
+              }
+            },
+            {
+              "name": "shipyard_policy",
+              "type": "Bytes",
+              "span": {
+                "dummy": false,
+                "start": 152,
+                "end": 174
+              }
+            }
+          ],
+          "span": {
+            "dummy": false,
+            "start": 105,
+            "end": 215
+          }
+        }
+      ],
+      "span": {
+        "dummy": false,
+        "start": 105,
+        "end": 215
+      }
+    }
+  ],
+  "assets": [
+    {
+      "name": "AdminToken",
+      "policy": {
+        "HexString": {
+          "value": "5ffc30389bee5838f5f25d015642f8d291769168145a80a686556e8a",
+          "span": {
+            "dummy": false,
+            "start": 19,
+            "end": 77
+          }
+        }
+      },
+      "asset_name": {
+        "String": {
+          "value": "Final Admin",
+          "span": {
+            "dummy": false,
+            "start": 78,
+            "end": 91
+          }
+        }
+      },
+      "span": {
+        "dummy": false,
+        "start": 0,
+        "end": 92
+      }
+    }
+  ],
+  "parties": [],
+  "policies": [],
+  "span": {
+    "dummy": false,
+    "start": 0,
+    "end": 768
+  }
+}

--- a/examples/asteria_datum.testDatum.tir
+++ b/examples/asteria_datum.testDatum.tir
@@ -1,0 +1,114 @@
+{
+  "fees": "FeeQuery",
+  "references": [],
+  "inputs": [
+    {
+      "name": "asteria",
+      "query": {
+        "address": {
+          "String": "addr_test1wqdsuy97njefz53rkhd4v6a2kuqk0md5mrn996ygwekrdyq369wjg"
+        },
+        "min_amount": {
+          "Assets": [
+            {
+              "policy": {
+                "Bytes": [
+                  95,
+                  252,
+                  48,
+                  56,
+                  155,
+                  238,
+                  88,
+                  56,
+                  245,
+                  242,
+                  93,
+                  1,
+                  86,
+                  66,
+                  248,
+                  210,
+                  145,
+                  118,
+                  145,
+                  104,
+                  20,
+                  90,
+                  128,
+                  166,
+                  134,
+                  85,
+                  110,
+                  138
+                ]
+              },
+              "asset_name": {
+                "String": "Final Admin"
+              },
+              "amount": {
+                "Number": 1
+              }
+            }
+          ]
+        },
+        "ref": null
+      },
+      "refs": [],
+      "redeemer": null,
+      "policy": null
+    }
+  ],
+  "outputs": [
+    {
+      "address": {
+        "String": "addr_test1wqdsuy97njefz53rkhd4v6a2kuqk0md5mrn996ygwekrdyq369wjg"
+      },
+      "datum": {
+        "Struct": {
+          "constructor": 0,
+          "fields": [
+            {
+              "EvalBuiltIn": {
+                "Add": [
+                  {
+                    "EvalBuiltIn": {
+                      "Property": [
+                        {
+                          "EvalInput": "asteria"
+                        },
+                        0
+                      ]
+                    }
+                  },
+                  {
+                    "Number": 1
+                  }
+                ]
+              }
+            },
+            {
+              "EvalBuiltIn": {
+                "Property": [
+                  {
+                    "EvalInput": "asteria"
+                  },
+                  1
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "amount": {
+        "EvalInput": "asteria"
+      }
+    }
+  ],
+  "validity": null,
+  "mints": [],
+  "adhoc": [],
+  "collateral": [],
+  "signers": null,
+  "metadata": []
+}

--- a/examples/asteria_datum.tx3
+++ b/examples/asteria_datum.tx3
@@ -1,0 +1,27 @@
+asset AdminToken = 0x5ffc30389bee5838f5f25d015642f8d291769168145a80a686556e8a."Final Admin";
+
+// Asteria
+type AsteriaDatum {
+    ship_counter: Int,
+    shipyard_policy: Bytes, // Is possible to define a maxLength?
+}
+
+tx testDatum() {
+    input asteria {
+        // Asteria Contract
+        from: "addr_test1wqdsuy97njefz53rkhd4v6a2kuqk0md5mrn996ygwekrdyq369wjg",
+        min_amount: AdminToken(1),
+        datum_is: AsteriaDatum,
+    }
+
+    // Output - Pay to Contract
+    output {
+        // Asteria Contract
+        to: "addr_test1wqdsuy97njefz53rkhd4v6a2kuqk0md5mrn996ygwekrdyq369wjg",
+        amount: asteria,
+        datum: AsteriaDatum {
+            ship_counter: asteria.ship_counter + 1,
+            shipyard_policy: asteria.shipyard_policy,
+        },
+    }
+}


### PR DESCRIPTION
This includes a test for datum outputs that includes a datum input.

Current test output:
```
---- resolve::tests::asteria_datum_test stdout ----
[crates/tx3-cardano/src/resolve.rs:223:9] &tx.find_params() = {}

thread 'resolve::tests::asteria_datum_test' panicked at crates/tx3-cardano/src/resolve.rs:241:10:
called `Result::unwrap()` on an `Err` value: ApplyError(PropertyIndexNotFound(0, "UtxoSet({Utxo { ref: UtxoRef { txid: [38, 122, 174, 53, 79, 13, 20, 216, 40, 119, 250, 87, 32, 247, 221, 201, 176, 227, 238, 163, 205, 42, 7, 87, 175, 119, 219, 77, 151, 91, 168, 28], index: 0 }, address: [1, 158, 56, 80, 3, 97, 138, 11, 77, 174, 227, 220, 115, 173, 230, 69, 208, 72, 166, 145, 191, 125, 171, 4, 199, 226, 106, 93, 108, 163, 154, 184, 56, 55, 113, 27, 210, 132, 208, 59, 221, 126, 30, 38, 23, 249, 254, 14, 90, 132, 37, 145, 80, 181, 239, 184, 116], datum: Some(Struct(StructExpr { constructor: 0, fields: [Number(13), Bytes([97, 98, 99])] })), assets: [AssetExpr { policy: None, asset_name: None, amount: Number(500000000) }], script: None }})"))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```