### PR TITLE
Feat/compute min utxo

### DIFF
--- a/crates/tx3-cardano/src/compile/mod.rs
+++ b/crates/tx3-cardano/src/compile/mod.rs
@@ -138,22 +138,6 @@ fn compile_value(ir: &ir::AssetExpr) -> Result<primitives::Value, Error> {
     }
 }
 
-// calculate min utxo lovelace according to spec
-// https://cips.cardano.org/cip/CIP-55
-
-/*
-fn eval_minutxo_constructor(&self, ctr: &ir::AssetConstructor) -> Result<primitives::Value, Error> {
-    let ratio = self.ledger.get_pparams()?.coins_per_utxo_byte;
-    let output = self.eval.find_output(ctr.name.as_str())?;
-    let serialized = pallas_codec::minicbor::to_vec(output).unwrap();
-    let min_lovelace = (160u64 + serialized.len() as u64) * ratio;
-
-    Ok(value!(min_lovelace as u64))
-
-    todo!()
-}
-    */
-
 fn compile_output_block(
     ir: &ir::Output,
     network: Network,
@@ -781,6 +765,27 @@ fn compute_script_data_hash(
     let data = primitives::ScriptData::build_for(witness_set, language_view);
 
     data.map(|x| x.hash())
+}
+
+// Compute min utxo lovelace according to spec
+// https://cips.cardano.org/cip/CIP-55
+pub fn compute_min_utxo(
+    x: ir::Expression,
+    tx_body: &Option<crate::TxBody>,
+    coins_per_byte: i128,
+) -> Result<i128, Error> {
+    let index = coercion::expr_into_number(&x)?;
+    let overhead = 160;
+
+    let total_bytes = if let Some(body) = tx_body {
+        let utxo = body.outputs.get(index as usize).unwrap();
+        let bytes = pallas::codec::minicbor::to_vec(utxo).unwrap().len() as i128;
+        bytes + overhead
+    } else {
+        crate::MIN_UTXO_BYTES
+    };
+
+    Ok(total_bytes * coins_per_byte)
 }
 
 pub fn entry_point(tx: &ir::Tx, pparams: &PParams) -> Result<primitives::Tx<'static>, Error> {

--- a/crates/tx3-cardano/src/lib.rs
+++ b/crates/tx3-cardano/src/lib.rs
@@ -89,6 +89,18 @@ impl tx3_lang::backend::Compiler for Compiler {
                 let address = coercion::policy_into_address(hash.as_ref(), self.pparams.network)?;
                 Ok(ir::Expression::Address(address.to_vec()))
             }
+            ir::CompilerOp::ComputeMinUtxo(x) => {
+                let lovelace = compile::compute_min_utxo(
+                    x,
+                    &self.latest_tx_body,
+                    self.pparams.coins_per_utxo_byte as i128,
+                )?;
+                Ok(ir::Expression::Assets(vec![ir::AssetExpr {
+                    policy: ir::Expression::None,
+                    asset_name: ir::Expression::None,
+                    amount: ir::Expression::Number(lovelace),
+                }]))
+            }
         }
     }
 }

--- a/crates/tx3-cardano/src/lib.rs
+++ b/crates/tx3-cardano/src/lib.rs
@@ -32,20 +32,29 @@ pub const EXECUTION_UNITS: primitives::ExUnits = primitives::ExUnits {
 };
 
 const DEFAULT_EXTRA_FEES: u64 = 200_000;
+const MIN_UTXO_BYTES: i128 = 197;
 
 #[derive(Debug, Clone, Default)]
 pub struct Config {
     pub extra_fees: Option<u64>,
 }
 
+pub type TxBody =
+    pallas::codec::utils::KeepRaw<'static, primitives::conway::TransactionBody<'static>>;
+
 pub struct Compiler {
     pub pparams: PParams,
     pub config: Config,
+    pub latest_tx_body: Option<TxBody>,
 }
 
 impl Compiler {
     pub fn new(pparams: PParams, config: Config) -> Self {
-        Self { pparams, config }
+        Self {
+            pparams,
+            config,
+            latest_tx_body: None,
+        }
     }
 }
 

--- a/crates/tx3-cardano/src/lib.rs
+++ b/crates/tx3-cardano/src/lib.rs
@@ -60,13 +60,12 @@ impl Compiler {
 
 impl tx3_lang::backend::Compiler for Compiler {
     fn compile(&mut self, tx: &tx3_lang::ir::Tx) -> Result<TxEval, tx3_lang::backend::Error> {
-        let tx = compile::entry_point(tx, &self.pparams)?;
+        let compiled_tx = compile::entry_point(tx, &self.pparams)?;
 
-        self.latest_tx_body = Some(tx.transaction_body.clone());
+        let hash = compiled_tx.transaction_body.compute_hash();
+        let payload = pallas::codec::minicbor::to_vec(&compiled_tx).unwrap();
 
-        let hash = tx.transaction_body.compute_hash();
-
-        let payload = pallas::codec::minicbor::to_vec(&tx).unwrap();
+        self.latest_tx_body = Some(compiled_tx.transaction_body);
 
         let size_fees = eval_size_fees(&payload, &self.pparams, self.config.extra_fees);
 

--- a/crates/tx3-cardano/src/lib.rs
+++ b/crates/tx3-cardano/src/lib.rs
@@ -59,8 +59,10 @@ impl Compiler {
 }
 
 impl tx3_lang::backend::Compiler for Compiler {
-    fn compile(&self, tx: &tx3_lang::ir::Tx) -> Result<TxEval, tx3_lang::backend::Error> {
+    fn compile(&mut self, tx: &tx3_lang::ir::Tx) -> Result<TxEval, tx3_lang::backend::Error> {
         let tx = compile::entry_point(tx, &self.pparams)?;
+
+        self.latest_tx_body = Some(tx.transaction_body.clone());
 
         let hash = tx.transaction_body.compute_hash();
 

--- a/crates/tx3-cardano/src/tests.rs
+++ b/crates/tx3-cardano/src/tests.rs
@@ -450,3 +450,37 @@ async fn extra_fees_zero_test() {
     assert!(!tx.payload.is_empty());
     assert!(tx.fee < DEFAULT_EXTRA_FEES);
 }
+
+#[pollster::test]
+async fn min_utxo_test() {
+    let mut compiler = test_compiler(None);
+    let utxos = wildcard_utxos(None);
+    let protocol = load_protocol("min_utxo");
+
+    let tx = protocol.new_tx("transfer_min")
+        .unwrap()
+        .with_arg("Sender", address_to_bytes("addr1qx0rs5qrvx9qkndwu0w88t0xghgy3f53ha76kpx8uf496m9rn2ursdm3r0fgf5pmm4lpufshl8lquk5yykg4pd00hp6quf2hh2"))
+        .with_arg("Receiver", address_to_bytes("addr1qx0rs5qrvx9qkndwu0w88t0xghgy3f53ha76kpx8uf496m9rn2ursdm3r0fgf5pmm4lpufshl8lquk5yykg4pd00hp6quf2hh2"))
+        .apply()
+        .unwrap();
+
+    let tx = test_compile(tx.into(), &mut compiler, utxos);
+
+    // 224 is the min amount of ada of the first utxo (why? (64 bytes + 160 fixed byets) * 1 coin_per_utxo_byte)
+    assert_eq!(
+        hex::encode(tx.hash),
+        "5853a69e54df5fe4e98692beca8d7d767575617af87b2e971b7c503172de8cb3"
+    );
+}
+
+#[pollster::test]
+async fn min_utxo_compiler_op_test() {
+    let compiler = test_compiler(None);
+
+    let result = compiler.execute(ir::CompilerOp::ComputeMinUtxo(ir::Expression::Number(0)));
+
+    assert!(result.is_ok());
+    if let Ok(ir::Expression::Assets(assets)) = result {
+        assert!(!assets.is_empty());
+    }
+}

--- a/crates/tx3-lang/src/analyzing.rs
+++ b/crates/tx3-lang/src/analyzing.rs
@@ -1180,4 +1180,42 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn test_min_utxo_analysis() {
+        let mut ast = crate::parsing::parse_string(
+            r#"
+        party Alice;
+        tx test() {
+            output my_output {
+                to: Alice,
+                amount: min_utxo(my_output),
+            }
+        }
+    "#,
+        )
+        .unwrap();
+
+        let result = analyze(&mut ast);
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn test_min_utxo_undefined_output_error() {
+        let mut ast = crate::parsing::parse_string(
+            r#"
+        party Alice;
+        tx test() {
+            output {
+                to: Alice,
+                amount: min_utxo(nonexistent_output),
+            }
+        }
+    "#,
+        )
+        .unwrap();
+
+        let result = analyze(&mut ast);
+        assert!(!result.errors.is_empty());
+    }
 }

--- a/crates/tx3-lang/src/applying.rs
+++ b/crates/tx3-lang/src/applying.rs
@@ -131,9 +131,7 @@ impl Arithmetic for i128 {
 
 impl Arithmetic for ir::Expression {
     fn add(self, other: ir::Expression) -> Result<ir::Expression, Error> {
-        if matches!(self, ir::Expression::EvalCompiler(_))
-            || matches!(other, ir::Expression::EvalCompiler(_))
-        {
+        if self.contains_eval_compiler() || other.contains_eval_compiler() {
             Ok(Self::from_builtin(ir::BuiltInOp::Add(self, other)))
         } else {
             match self {
@@ -150,9 +148,7 @@ impl Arithmetic for ir::Expression {
     }
 
     fn sub(self, other: ir::Expression) -> Result<ir::Expression, Error> {
-        if matches!(self, ir::Expression::EvalCompiler(_))
-            || matches!(other, ir::Expression::EvalCompiler(_))
-        {
+        if self.contains_eval_compiler() || other.contains_eval_compiler() {
             Ok(Self::from_builtin(ir::BuiltInOp::Sub(self, other)))
         } else {
             match self {

--- a/crates/tx3-lang/src/applying.rs
+++ b/crates/tx3-lang/src/applying.rs
@@ -131,33 +131,46 @@ impl Arithmetic for i128 {
 
 impl Arithmetic for ir::Expression {
     fn add(self, other: ir::Expression) -> Result<ir::Expression, Error> {
-        match self {
-            ir::Expression::None => Ok(other),
-            ir::Expression::Number(x) => Arithmetic::add(x, other),
-            ir::Expression::Assets(x) => Arithmetic::add(x, other),
-            x => Err(Error::InvalidBinaryOp(
-                "add".to_string(),
-                format!("{x:?}"),
-                format!("{other:?}"),
-            )),
+        if matches!(self, ir::Expression::EvalCompiler(_))
+            || matches!(other, ir::Expression::EvalCompiler(_))
+        {
+            Ok(Self::from_builtin(ir::BuiltInOp::Add(self, other)))
+        } else {
+            match self {
+                ir::Expression::None => Ok(other),
+                ir::Expression::Number(x) => Arithmetic::add(x, other),
+                ir::Expression::Assets(x) => Arithmetic::add(x, other),
+                x => Err(Error::InvalidBinaryOp(
+                    "add".to_string(),
+                    format!("{x:?}"),
+                    format!("{other:?}"),
+                )),
+            }
         }
     }
 
     fn sub(self, other: ir::Expression) -> Result<ir::Expression, Error> {
-        match self {
-            ir::Expression::None => Ok(other),
-            ir::Expression::Number(x) => Arithmetic::sub(x, other),
-            ir::Expression::Assets(x) => Arithmetic::sub(x, other),
-            x => Err(Error::InvalidBinaryOp(
-                "sub".to_string(),
-                format!("{x:?}"),
-                format!("{other:?}"),
-            )),
+        if matches!(self, ir::Expression::EvalCompiler(_))
+            || matches!(other, ir::Expression::EvalCompiler(_))
+        {
+            Ok(Self::from_builtin(ir::BuiltInOp::Sub(self, other)))
+        } else {
+            match self {
+                ir::Expression::None => Ok(other),
+                ir::Expression::Number(x) => Arithmetic::sub(x, other),
+                ir::Expression::Assets(x) => Arithmetic::sub(x, other),
+                x => Err(Error::InvalidBinaryOp(
+                    "sub".to_string(),
+                    format!("{x:?}"),
+                    format!("{other:?}"),
+                )),
+            }
         }
     }
 
     fn neg(self) -> Result<ir::Expression, Error> {
         match self {
+            ir::Expression::EvalCompiler(_) => Ok(Self::from_builtin(ir::BuiltInOp::Negate(self))),
             ir::Expression::None => Ok(ir::Expression::None),
             ir::Expression::Number(x) => Arithmetic::neg(x),
             ir::Expression::Assets(x) => Arithmetic::neg(x),
@@ -1125,6 +1138,7 @@ impl Composite for ir::CompilerOp {
     fn components(&self) -> Vec<&ir::Expression> {
         match self {
             ir::CompilerOp::BuildScriptAddress(x) => vec![x],
+            ir::CompilerOp::ComputeMinUtxo(x) => vec![x],
         }
     }
 
@@ -1134,6 +1148,7 @@ impl Composite for ir::CompilerOp {
     {
         match self {
             ir::CompilerOp::BuildScriptAddress(x) => Ok(ir::CompilerOp::BuildScriptAddress(f(x)?)),
+            ir::CompilerOp::ComputeMinUtxo(x) => Ok(ir::CompilerOp::ComputeMinUtxo(f(x)?)),
         }
     }
 }

--- a/crates/tx3-lang/src/applying.rs
+++ b/crates/tx3-lang/src/applying.rs
@@ -1889,4 +1889,40 @@ mod tests {
             _ => panic!("Expected string 'hello'"),
         }
     }
+
+    #[test]
+    fn test_min_utxo_add_non_reduction() {
+        let op = ir::Expression::from_builtin(ir::BuiltInOp::Add(
+            ir::Expression::Assets(vec![ir::AssetExpr {
+                policy: ir::Expression::None,
+                asset_name: ir::Expression::None,
+                amount: ir::Expression::Number(29),
+            }]),
+            ir::Expression::EvalCompiler(Box::new(ir::CompilerOp::ComputeMinUtxo(
+                ir::Expression::Number(20),
+            ))),
+        ));
+
+        let reduced = op.clone().reduce().unwrap();
+
+        assert!(op == reduced)
+    }
+
+    #[test]
+    fn test_min_utxo_sub_non_reduction() {
+        let op = ir::Expression::from_builtin(ir::BuiltInOp::Sub(
+            ir::Expression::Assets(vec![ir::AssetExpr {
+                policy: ir::Expression::None,
+                asset_name: ir::Expression::None,
+                amount: ir::Expression::Number(29),
+            }]),
+            ir::Expression::EvalCompiler(Box::new(ir::CompilerOp::ComputeMinUtxo(
+                ir::Expression::Number(20),
+            ))),
+        ));
+
+        let reduced = op.clone().reduce().unwrap();
+
+        assert!(op == reduced)
+    }
 }

--- a/crates/tx3-lang/src/ast.rs
+++ b/crates/tx3-lang/src/ast.rs
@@ -22,6 +22,7 @@ pub enum Symbol {
     EnvVar(String, Box<Type>),
     ParamVar(String, Box<Type>),
     LocalExpr(Box<DataExpr>),
+    Output(usize),
     Input(Box<InputBlock>),
     PartyDef(Box<PartyDef>),
     PolicyDef(Box<PolicyDef>),
@@ -389,7 +390,7 @@ impl OutputBlockField {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OutputBlock {
-    pub name: Option<String>,
+    pub name: Option<Identifier>,
     pub fields: Vec<OutputBlockField>,
     pub span: Span,
 }
@@ -697,6 +698,7 @@ pub enum DataExpr {
     StaticAssetConstructor(StaticAssetConstructor),
     AnyAssetConstructor(AnyAssetConstructor),
     Identifier(Identifier),
+    MinUtxo(Identifier),
     AddOp(AddOp),
     SubOp(SubOp),
     ConcatOp(ConcatOp),
@@ -732,6 +734,7 @@ impl DataExpr {
             DataExpr::StaticAssetConstructor(x) => x.target_type(),
             DataExpr::AnyAssetConstructor(x) => x.target_type(),
             DataExpr::UtxoRef(_) => Some(Type::UtxoRef),
+            DataExpr::MinUtxo(_) => Some(Type::AnyAsset),
         }
     }
 }

--- a/crates/tx3-lang/src/backend.rs
+++ b/crates/tx3-lang/src/backend.rs
@@ -53,7 +53,7 @@ pub struct TxEval {
 }
 
 pub trait Compiler {
-    fn compile(&self, tx: &ir::Tx) -> Result<TxEval, Error>;
+    fn compile(&mut self, tx: &ir::Tx) -> Result<TxEval, Error>;
     fn execute(&self, op: ir::CompilerOp) -> Result<ir::Expression, Error>;
 }
 

--- a/crates/tx3-lang/src/ir.rs
+++ b/crates/tx3-lang/src/ir.rs
@@ -265,68 +265,6 @@ impl Expression {
             _ => None,
         }
     }
-
-    pub fn from_builtin(op: BuiltInOp) -> Self {
-        Self::EvalBuiltIn(Box::new(op))
-    }
-
-    /// Check if the expression contains an `EvalCompiler` expression.
-    pub fn contains_eval_compiler(&self) -> bool {
-        match self {
-            Self::List(xs) => xs.iter().any(|x| x.contains_eval_compiler()),
-            Self::Tuple(tuple) => {
-                tuple.0.contains_eval_compiler() || tuple.1.contains_eval_compiler()
-            }
-            Self::Struct(s) => s.fields.iter().any(|x| x.contains_eval_compiler()),
-            Self::Assets(x) => x.iter().any(|x| {
-                x.amount.contains_eval_compiler()
-                    || x.policy.contains_eval_compiler()
-                    || x.asset_name.contains_eval_compiler()
-            }),
-            Self::EvalParam(x) => match **x {
-                Param::Set(ref x) => x.contains_eval_compiler(),
-                Param::ExpectInput(_, ref q) => {
-                    q.min_amount.contains_eval_compiler()
-                        || q.address.contains_eval_compiler()
-                        || q.r#ref.contains_eval_compiler()
-                }
-                Param::ExpectValue(_, _) | Param::ExpectFees => false,
-            },
-            Self::EvalCoerce(x) => match **x {
-                Coerce::NoOp(ref x) => x.contains_eval_compiler(),
-                Coerce::IntoAssets(ref x) => x.contains_eval_compiler(),
-                Coerce::IntoDatum(ref x) => x.contains_eval_compiler(),
-                Coerce::IntoScript(ref x) => x.contains_eval_compiler(),
-            },
-            Self::AdHocDirective(x) => x.data.values().any(|v| v.contains_eval_compiler()),
-            Self::EvalBuiltIn(x) => match **x {
-                BuiltInOp::NoOp(ref x) => x.contains_eval_compiler(),
-                BuiltInOp::Add(ref a, ref b) => {
-                    a.contains_eval_compiler() || b.contains_eval_compiler()
-                }
-                BuiltInOp::Sub(ref a, ref b) => {
-                    a.contains_eval_compiler() || b.contains_eval_compiler()
-                }
-                BuiltInOp::Concat(ref a, ref b) => {
-                    a.contains_eval_compiler() || b.contains_eval_compiler()
-                }
-                BuiltInOp::Negate(ref x) => x.contains_eval_compiler(),
-                BuiltInOp::Property(ref x, _) => x.contains_eval_compiler(),
-            },
-            Self::EvalCompiler(_) => true,
-            // variants never contain EvalCompiler operations
-            // Don't add _ here, as it will match future variants
-            Self::UtxoRefs(_)
-            | Self::UtxoSet(_)
-            | Self::Hash(_)
-            | Self::Address(_)
-            | Self::String(_)
-            | Self::Bytes(_)
-            | Self::Number(_)
-            | Self::Bool(_)
-            | Self::None => false,
-        }
-    }
 }
 
 impl From<BuiltInOp> for Expression {

--- a/crates/tx3-lang/src/ir.rs
+++ b/crates/tx3-lang/src/ir.rs
@@ -269,6 +269,64 @@ impl Expression {
     pub fn from_builtin(op: BuiltInOp) -> Self {
         Self::EvalBuiltIn(Box::new(op))
     }
+
+    /// Check if the expression contains an `EvalCompiler` expression.
+    pub fn contains_eval_compiler(&self) -> bool {
+        match self {
+            Self::List(xs) => xs.iter().any(|x| x.contains_eval_compiler()),
+            Self::Tuple(tuple) => {
+                tuple.0.contains_eval_compiler() || tuple.1.contains_eval_compiler()
+            }
+            Self::Struct(s) => s.fields.iter().any(|x| x.contains_eval_compiler()),
+            Self::Assets(x) => x.iter().any(|x| {
+                x.amount.contains_eval_compiler()
+                    || x.policy.contains_eval_compiler()
+                    || x.asset_name.contains_eval_compiler()
+            }),
+            Self::EvalParam(x) => match **x {
+                Param::Set(ref x) => x.contains_eval_compiler(),
+                Param::ExpectInput(_, ref q) => {
+                    q.min_amount.contains_eval_compiler()
+                        || q.address.contains_eval_compiler()
+                        || q.r#ref.contains_eval_compiler()
+                }
+                Param::ExpectValue(_, _) | Param::ExpectFees => false,
+            },
+            Self::EvalCoerce(x) => match **x {
+                Coerce::NoOp(ref x) => x.contains_eval_compiler(),
+                Coerce::IntoAssets(ref x) => x.contains_eval_compiler(),
+                Coerce::IntoDatum(ref x) => x.contains_eval_compiler(),
+                Coerce::IntoScript(ref x) => x.contains_eval_compiler(),
+            },
+            Self::AdHocDirective(x) => x.data.values().any(|v| v.contains_eval_compiler()),
+            Self::EvalBuiltIn(x) => match **x {
+                BuiltInOp::NoOp(ref x) => x.contains_eval_compiler(),
+                BuiltInOp::Add(ref a, ref b) => {
+                    a.contains_eval_compiler() || b.contains_eval_compiler()
+                }
+                BuiltInOp::Sub(ref a, ref b) => {
+                    a.contains_eval_compiler() || b.contains_eval_compiler()
+                }
+                BuiltInOp::Concat(ref a, ref b) => {
+                    a.contains_eval_compiler() || b.contains_eval_compiler()
+                }
+                BuiltInOp::Negate(ref x) => x.contains_eval_compiler(),
+                BuiltInOp::Property(ref x, _) => x.contains_eval_compiler(),
+            },
+            Self::EvalCompiler(_) => true,
+            // variants never contain EvalCompiler operations
+            // Don't add _ here, as it will match future variants
+            Self::UtxoRefs(_)
+            | Self::UtxoSet(_)
+            | Self::Hash(_)
+            | Self::Address(_)
+            | Self::String(_)
+            | Self::Bytes(_)
+            | Self::Number(_)
+            | Self::Bool(_)
+            | Self::None => false,
+        }
+    }
 }
 
 impl From<BuiltInOp> for Expression {

--- a/crates/tx3-lang/src/ir.rs
+++ b/crates/tx3-lang/src/ir.rs
@@ -71,6 +71,7 @@ pub enum BuiltInOp {
 #[derive(Encode, Decode, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum CompilerOp {
     BuildScriptAddress(Expression),
+    ComputeMinUtxo(Expression),
 }
 
 #[derive(Encode, Decode, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -263,6 +264,10 @@ impl Expression {
             Self::UtxoRefs(refs) => Some(refs),
             _ => None,
         }
+    }
+
+    pub fn from_builtin(op: BuiltInOp) -> Self {
+        Self::EvalBuiltIn(Box::new(op))
     }
 }
 
@@ -458,6 +463,7 @@ impl Node for CompilerOp {
     fn apply<V: Visitor>(self, visitor: &mut V) -> Result<Self, crate::applying::Error> {
         let visited = match self {
             CompilerOp::BuildScriptAddress(x) => CompilerOp::BuildScriptAddress(x.apply(visitor)?),
+            CompilerOp::ComputeMinUtxo(x) => CompilerOp::ComputeMinUtxo(x.apply(visitor)?),
         };
 
         Ok(visited)

--- a/crates/tx3-lang/src/lowering.rs
+++ b/crates/tx3-lang/src/lowering.rs
@@ -195,6 +195,7 @@ impl IntoLower for ast::Identifier {
                     Ok(policy.hash)
                 }
             }
+            ast::Symbol::Output(index) => Ok(ir::Expression::Number(*index as i128)),
             _ => {
                 dbg!(&self);
                 todo!();
@@ -445,6 +446,9 @@ impl IntoLower for ast::DataExpr {
             ast::DataExpr::NegateOp(x) => x.into_lower(ctx)?,
             ast::DataExpr::PropertyOp(x) => x.into_lower(ctx)?,
             ast::DataExpr::UtxoRef(x) => x.into_lower(ctx)?,
+            ast::DataExpr::MinUtxo(x) => ir::Expression::EvalCompiler(Box::new(
+                ir::CompilerOp::ComputeMinUtxo(x.into_lower(ctx)?),
+            )),
         };
 
         Ok(out)

--- a/crates/tx3-lang/src/lowering.rs
+++ b/crates/tx3-lang/src/lowering.rs
@@ -902,4 +902,6 @@ mod tests {
     test_lowering!(cardano_witness);
 
     test_lowering!(burn);
+
+    test_lowering!(min_utxo);
 }

--- a/crates/tx3-lang/src/parsing.rs
+++ b/crates/tx3-lang/src/parsing.rs
@@ -1089,6 +1089,11 @@ impl DataExpr {
         )?))
     }
 
+    fn min_utxo_parse(pair: Pair<Rule>) -> Result<Self, Error> {
+        let inner = pair.into_inner().next().unwrap();
+        Ok(DataExpr::MinUtxo(Identifier::parse(inner)?))
+    }
+
     fn concat_constructor_parse(pair: Pair<Rule>) -> Result<Self, Error> {
         Ok(DataExpr::ConcatOp(ConcatOp::parse(pair)?))
     }
@@ -1160,6 +1165,7 @@ impl AstNode for DataExpr {
                 Rule::static_asset_constructor => DataExpr::static_asset_constructor_parse(x),
                 Rule::any_asset_constructor => DataExpr::any_asset_constructor_parse(x),
                 Rule::concat_constructor => DataExpr::concat_constructor_parse(x),
+                Rule::min_utxo => DataExpr::min_utxo_parse(x),
                 Rule::data_expr => DataExpr::parse(x),
                 x => unreachable!("unexpected rule as data primary: {:?}", x),
             })
@@ -1198,6 +1204,7 @@ impl AstNode for DataExpr {
             DataExpr::NegateOp(x) => &x.span,
             DataExpr::PropertyOp(x) => &x.span,
             DataExpr::UtxoRef(x) => x.span(),
+            DataExpr::MinUtxo(x) => x.span(),
         }
     }
 }

--- a/crates/tx3-lang/src/parsing.rs
+++ b/crates/tx3-lang/src/parsing.rs
@@ -1950,6 +1950,28 @@ mod tests {
     );
 
     input_to_ast_check!(
+        DataExpr,
+        "min_utxo_basic",
+        "min_utxo(output1)",
+        DataExpr::MinUtxo(Identifier::new("output1"))
+    );
+
+    input_to_ast_check!(
+        DataExpr,
+        "min_utxo_in_expression",
+        "Ada(100) + min_utxo(my_output)",
+        DataExpr::AddOp(AddOp {
+            lhs: Box::new(DataExpr::StaticAssetConstructor(StaticAssetConstructor {
+                r#type: Identifier::new("Ada"),
+                amount: Box::new(DataExpr::Number(100)),
+                span: Span::DUMMY,
+            })),
+            rhs: Box::new(DataExpr::MinUtxo(Identifier::new("my_output"))),
+            span: Span::DUMMY,
+        })
+    );
+
+    input_to_ast_check!(
         StructConstructor,
         "struct_constructor_record",
         "MyRecord {
@@ -2329,7 +2351,7 @@ mod tests {
     #[test]
     fn test_spans_are_respected() {
         let program = parse_well_known_example("lang_tour");
-        assert_eq!(program.span, Span::new(0, 1497));
+        assert_eq!(program.span, Span::new(0, 1560));
 
         assert_eq!(program.parties[0].span, Span::new(47, 61));
 

--- a/crates/tx3-lang/src/parsing.rs
+++ b/crates/tx3-lang/src/parsing.rs
@@ -1438,18 +1438,6 @@ mod tests {
     use pest::Parser;
 
     #[test]
-    fn test_min_utxo_invalid_syntax() {
-        let result = parse_string("tx test() { output { amount: min_utxo(), } }");
-        assert!(result.is_err()); // Should fail - missing identifier
-    }
-
-    #[test]
-    fn test_min_utxo_wrong_arguments() {
-        let result = parse_string("tx test() { output { amount: min_utxo(a, b), } }");
-        assert!(result.is_err()); // Should fail - too many arguments
-    }
-
-    #[test]
     fn smoke_test_parse_string() {
         let _ = parse_string("tx swap() {}").unwrap();
     }

--- a/crates/tx3-lang/src/parsing.rs
+++ b/crates/tx3-lang/src/parsing.rs
@@ -590,7 +590,11 @@ impl AstNode for OutputBlock {
             .map(|x| x.as_rule() == Rule::identifier)
             .unwrap_or_default();
 
-        let name = has_name.then(|| inner.next().unwrap().as_str().to_string());
+        let name = if has_name {
+            Some(Identifier::parse(inner.next().unwrap())?)
+        } else {
+            None
+        };
 
         let fields = inner
             .map(|x| OutputBlockField::parse(x))

--- a/crates/tx3-lang/src/parsing.rs
+++ b/crates/tx3-lang/src/parsing.rs
@@ -1438,6 +1438,18 @@ mod tests {
     use pest::Parser;
 
     #[test]
+    fn test_min_utxo_invalid_syntax() {
+        let result = parse_string("tx test() { output { amount: min_utxo(), } }");
+        assert!(result.is_err()); // Should fail - missing identifier
+    }
+
+    #[test]
+    fn test_min_utxo_wrong_arguments() {
+        let result = parse_string("tx test() { output { amount: min_utxo(a, b), } }");
+        assert!(result.is_err()); // Should fail - too many arguments
+    }
+
+    #[test]
     fn smoke_test_parse_string() {
         let _ = parse_string("tx swap() {}").unwrap();
     }

--- a/crates/tx3-lang/src/tx3.pest
+++ b/crates/tx3-lang/src/tx3.pest
@@ -124,6 +124,8 @@ concat_constructor = {
     "concat" ~ "(" ~ data_expr ~ "," ~ data_expr ~ ")"
 }
 
+min_utxo = { "min_utxo" ~ "(" ~ identifier ~ ")" }
+
 data_expr = { data_prefix* ~ data_primary ~ data_postfix* ~ (data_infix ~ data_prefix* ~ data_primary ~ data_postfix* )* }
 
     data_infix = _{ data_add | data_sub }
@@ -143,6 +145,7 @@ data_expr = { data_prefix* ~ data_primary ~ data_postfix* ~ (data_infix ~ data_p
         number |
         bool |
         string |
+        min_utxo |
         struct_constructor |
         list_constructor |
         concat_constructor |

--- a/crates/tx3-resolver/src/lib.rs
+++ b/crates/tx3-resolver/src/lib.rs
@@ -32,7 +32,7 @@ pub enum Error {
 
 async fn eval_pass<C: Compiler, S: UtxoStore>(
     tx: &ir::Tx,
-    compiler: &C,
+    compiler: &mut C,
     utxos: &S,
     last_eval: Option<&TxEval>,
 ) -> Result<Option<TxEval>, Error> {

--- a/crates/tx3-resolver/src/lib.rs
+++ b/crates/tx3-resolver/src/lib.rs
@@ -42,6 +42,8 @@ async fn eval_pass<C: Compiler, S: UtxoStore>(
 
     let attempt = applying::apply_fees(attempt, fees)?;
 
+    let attempt = attempt.apply(compiler)?;
+
     let attempt = applying::reduce(attempt)?;
 
     let attempt = crate::inputs::resolve(attempt, utxos).await?;
@@ -83,7 +85,6 @@ pub async fn resolve_tx<C: Compiler, S: UtxoStore>(
 
     // reduce compiler ops
     let tx = ir::Tx::from(tx);
-    let tx = tx.apply(compiler)?;
 
     while let Some(better) = eval_pass(&tx, compiler, utxos, last_eval.as_ref()).await? {
         last_eval = Some(better);

--- a/examples/cardano_witness.mint_from_plutus.tir
+++ b/examples/cardano_witness.mint_from_plutus.tir
@@ -201,9 +201,6 @@
     {
       "name": "plutus_witness",
       "data": {
-        "version": {
-          "Number": 3
-        },
         "script": {
           "Bytes": [
             81,
@@ -225,6 +222,9 @@
             174,
             105
           ]
+        },
+        "version": {
+          "Number": 3
         }
       }
     }

--- a/examples/lang_tour.ast
+++ b/examples/lang_tour.ast
@@ -111,29 +111,48 @@
             },
             {
               "MinAmount": {
-                "StaticAssetConstructor": {
-                  "type": {
-                    "value": "Ada",
-                    "span": {
-                      "dummy": false,
-                      "start": 628,
-                      "end": 631
-                    }
-                  },
-                  "amount": {
-                    "Identifier": {
-                      "value": "quantity",
+                "AddOp": {
+                  "lhs": {
+                    "StaticAssetConstructor": {
+                      "type": {
+                        "value": "Ada",
+                        "span": {
+                          "dummy": false,
+                          "start": 628,
+                          "end": 631
+                        }
+                      },
+                      "amount": {
+                        "Identifier": {
+                          "value": "quantity",
+                          "span": {
+                            "dummy": false,
+                            "start": 632,
+                            "end": 640
+                          }
+                        }
+                      },
                       "span": {
                         "dummy": false,
-                        "start": 632,
-                        "end": 640
+                        "start": 628,
+                        "end": 641
+                      }
+                    }
+                  },
+                  "rhs": {
+                    "MinUtxo": {
+                      "value": "named_output",
+                      "span": {
+                        "dummy": false,
+                        "start": 653,
+                        "end": 665
                       }
                     }
                   },
                   "span": {
                     "dummy": false,
-                    "start": 628,
-                    "end": 641
+                    "start": 642,
+                    "end": 643
                   }
                 }
               }
@@ -145,8 +164,8 @@
                     "value": "MyVariant",
                     "span": {
                       "dummy": false,
-                      "start": 661,
-                      "end": 670
+                      "start": 686,
+                      "end": 695
                     }
                   },
                   "case": {
@@ -154,8 +173,8 @@
                       "value": "Case1",
                       "span": {
                         "dummy": false,
-                        "start": 672,
-                        "end": 677
+                        "start": 697,
+                        "end": 702
                       }
                     },
                     "fields": [
@@ -164,8 +183,8 @@
                           "value": "field1",
                           "span": {
                             "dummy": false,
-                            "start": 692,
-                            "end": 698
+                            "start": 717,
+                            "end": 723
                           }
                         },
                         "value": {
@@ -173,15 +192,15 @@
                             "value": "field_a",
                             "span": {
                               "dummy": false,
-                              "start": 700,
-                              "end": 707
+                              "start": 725,
+                              "end": 732
                             }
                           }
                         },
                         "span": {
                           "dummy": false,
-                          "start": 692,
-                          "end": 707
+                          "start": 717,
+                          "end": 732
                         }
                       },
                       {
@@ -189,8 +208,8 @@
                           "value": "field2",
                           "span": {
                             "dummy": false,
-                            "start": 721,
-                            "end": 727
+                            "start": 746,
+                            "end": 752
                           }
                         },
                         "value": {
@@ -198,15 +217,15 @@
                             "value": "AFAFAF",
                             "span": {
                               "dummy": false,
-                              "start": 729,
-                              "end": 737
+                              "start": 754,
+                              "end": 762
                             }
                           }
                         },
                         "span": {
                           "dummy": false,
-                          "start": 721,
-                          "end": 737
+                          "start": 746,
+                          "end": 762
                         }
                       },
                       {
@@ -214,8 +233,8 @@
                           "value": "field3",
                           "span": {
                             "dummy": false,
-                            "start": 751,
-                            "end": 757
+                            "start": 776,
+                            "end": 782
                           }
                         },
                         "value": {
@@ -223,29 +242,29 @@
                             "value": "quantity",
                             "span": {
                               "dummy": false,
-                              "start": 759,
-                              "end": 767
+                              "start": 784,
+                              "end": 792
                             }
                           }
                         },
                         "span": {
                           "dummy": false,
-                          "start": 751,
-                          "end": 767
+                          "start": 776,
+                          "end": 792
                         }
                       }
                     ],
                     "spread": null,
                     "span": {
                       "dummy": false,
-                      "start": 670,
-                      "end": 778
+                      "start": 695,
+                      "end": 803
                     }
                   },
                   "span": {
                     "dummy": false,
-                    "start": 661,
-                    "end": 778
+                    "start": 686,
+                    "end": 803
                   }
                 }
               }
@@ -254,13 +273,20 @@
           "span": {
             "dummy": false,
             "start": 542,
-            "end": 785
+            "end": 810
           }
         }
       ],
       "outputs": [
         {
-          "name": null,
+          "name": {
+            "value": "named_output",
+            "span": {
+              "dummy": false,
+              "start": 996,
+              "end": 1008
+            }
+          },
           "fields": [
             {
               "To": {
@@ -268,8 +294,8 @@
                   "value": "MyParty",
                   "span": {
                     "dummy": false,
-                    "start": 985,
-                    "end": 992
+                    "start": 1023,
+                    "end": 1030
                   }
                 }
               }
@@ -281,8 +307,8 @@
                     "value": "MyRecord",
                     "span": {
                       "dummy": false,
-                      "start": 1009,
-                      "end": 1017
+                      "start": 1047,
+                      "end": 1055
                     }
                   },
                   "case": {
@@ -300,8 +326,8 @@
                           "value": "field1",
                           "span": {
                             "dummy": false,
-                            "start": 1032,
-                            "end": 1038
+                            "start": 1070,
+                            "end": 1076
                           }
                         },
                         "value": {
@@ -309,15 +335,15 @@
                             "value": "quantity",
                             "span": {
                               "dummy": false,
-                              "start": 1040,
-                              "end": 1048
+                              "start": 1078,
+                              "end": 1086
                             }
                           }
                         },
                         "span": {
                           "dummy": false,
-                          "start": 1032,
-                          "end": 1048
+                          "start": 1070,
+                          "end": 1086
                         }
                       },
                       {
@@ -325,8 +351,8 @@
                           "value": "field2",
                           "span": {
                             "dummy": false,
-                            "start": 1062,
-                            "end": 1068
+                            "start": 1100,
+                            "end": 1106
                           }
                         },
                         "value": {
@@ -341,8 +367,8 @@
                                 },
                                 "span": {
                                   "dummy": false,
-                                  "start": 1074,
-                                  "end": 1075
+                                  "start": 1112,
+                                  "end": 1113
                                 }
                               }
                             },
@@ -356,22 +382,22 @@
                                 },
                                 "span": {
                                   "dummy": false,
-                                  "start": 1085,
-                                  "end": 1086
+                                  "start": 1123,
+                                  "end": 1124
                                 }
                               }
                             },
                             "span": {
                               "dummy": false,
-                              "start": 1080,
-                              "end": 1081
+                              "start": 1118,
+                              "end": 1119
                             }
                           }
                         },
                         "span": {
                           "dummy": false,
-                          "start": 1062,
-                          "end": 1089
+                          "start": 1100,
+                          "end": 1127
                         }
                       },
                       {
@@ -379,8 +405,8 @@
                           "value": "field4",
                           "span": {
                             "dummy": false,
-                            "start": 1103,
-                            "end": 1109
+                            "start": 1141,
+                            "end": 1147
                           }
                         },
                         "value": {
@@ -402,8 +428,8 @@
                                       "value": "source",
                                       "span": {
                                         "dummy": false,
-                                        "start": 1121,
-                                        "end": 1127
+                                        "start": 1159,
+                                        "end": 1165
                                       }
                                     }
                                   },
@@ -411,29 +437,29 @@
                                     "value": "field1",
                                     "span": {
                                       "dummy": false,
-                                      "start": 1128,
-                                      "end": 1134
+                                      "start": 1166,
+                                      "end": 1172
                                     }
                                   },
                                   "span": {
                                     "dummy": false,
-                                    "start": 1127,
-                                    "end": 1134
+                                    "start": 1165,
+                                    "end": 1172
                                   }
                                 }
                               }
                             ],
                             "span": {
                               "dummy": false,
-                              "start": 1111,
-                              "end": 1135
+                              "start": 1149,
+                              "end": 1173
                             }
                           }
                         },
                         "span": {
                           "dummy": false,
-                          "start": 1103,
-                          "end": 1135
+                          "start": 1141,
+                          "end": 1173
                         }
                       }
                     ],
@@ -442,21 +468,21 @@
                         "value": "source",
                         "span": {
                           "dummy": false,
-                          "start": 1152,
-                          "end": 1158
+                          "start": 1190,
+                          "end": 1196
                         }
                       }
                     },
                     "span": {
                       "dummy": false,
-                      "start": 1018,
-                      "end": 1168
+                      "start": 1056,
+                      "end": 1206
                     }
                   },
                   "span": {
                     "dummy": false,
-                    "start": 1009,
-                    "end": 1168
+                    "start": 1047,
+                    "end": 1206
                   }
                 }
               }
@@ -465,119 +491,138 @@
               "Amount": {
                 "AddOp": {
                   "lhs": {
-                    "AnyAssetConstructor": {
-                      "policy": {
-                        "PropertyOp": {
-                          "operand": {
-                            "Identifier": {
-                              "value": "source",
+                    "AddOp": {
+                      "lhs": {
+                        "AnyAssetConstructor": {
+                          "policy": {
+                            "PropertyOp": {
+                              "operand": {
+                                "Identifier": {
+                                  "value": "source",
+                                  "span": {
+                                    "dummy": false,
+                                    "start": 1233,
+                                    "end": 1239
+                                  }
+                                }
+                              },
+                              "property": {
+                                "value": "field3",
+                                "span": {
+                                  "dummy": false,
+                                  "start": 1240,
+                                  "end": 1246
+                                }
+                              },
                               "span": {
                                 "dummy": false,
-                                "start": 1195,
-                                "end": 1201
+                                "start": 1239,
+                                "end": 1246
                               }
                             }
                           },
-                          "property": {
-                            "value": "field3",
-                            "span": {
-                              "dummy": false,
-                              "start": 1202,
-                              "end": 1208
+                          "asset_name": {
+                            "PropertyOp": {
+                              "operand": {
+                                "Identifier": {
+                                  "value": "source",
+                                  "span": {
+                                    "dummy": false,
+                                    "start": 1248,
+                                    "end": 1254
+                                  }
+                                }
+                              },
+                              "property": {
+                                "value": "field2",
+                                "span": {
+                                  "dummy": false,
+                                  "start": 1255,
+                                  "end": 1261
+                                }
+                              },
+                              "span": {
+                                "dummy": false,
+                                "start": 1254,
+                                "end": 1261
+                              }
+                            }
+                          },
+                          "amount": {
+                            "PropertyOp": {
+                              "operand": {
+                                "Identifier": {
+                                  "value": "source",
+                                  "span": {
+                                    "dummy": false,
+                                    "start": 1263,
+                                    "end": 1269
+                                  }
+                                }
+                              },
+                              "property": {
+                                "value": "field1",
+                                "span": {
+                                  "dummy": false,
+                                  "start": 1270,
+                                  "end": 1276
+                                }
+                              },
+                              "span": {
+                                "dummy": false,
+                                "start": 1269,
+                                "end": 1276
+                              }
                             }
                           },
                           "span": {
                             "dummy": false,
-                            "start": 1201,
-                            "end": 1208
+                            "start": 1224,
+                            "end": 1277
                           }
                         }
                       },
-                      "asset_name": {
-                        "PropertyOp": {
-                          "operand": {
-                            "Identifier": {
-                              "value": "source",
-                              "span": {
-                                "dummy": false,
-                                "start": 1210,
-                                "end": 1216
-                              }
-                            }
-                          },
-                          "property": {
-                            "value": "field2",
+                      "rhs": {
+                        "StaticAssetConstructor": {
+                          "type": {
+                            "value": "Ada",
                             "span": {
                               "dummy": false,
-                              "start": 1217,
-                              "end": 1223
+                              "start": 1280,
+                              "end": 1283
                             }
+                          },
+                          "amount": {
+                            "Number": 40
                           },
                           "span": {
                             "dummy": false,
-                            "start": 1216,
-                            "end": 1223
-                          }
-                        }
-                      },
-                      "amount": {
-                        "PropertyOp": {
-                          "operand": {
-                            "Identifier": {
-                              "value": "source",
-                              "span": {
-                                "dummy": false,
-                                "start": 1225,
-                                "end": 1231
-                              }
-                            }
-                          },
-                          "property": {
-                            "value": "field1",
-                            "span": {
-                              "dummy": false,
-                              "start": 1232,
-                              "end": 1238
-                            }
-                          },
-                          "span": {
-                            "dummy": false,
-                            "start": 1231,
-                            "end": 1238
+                            "start": 1280,
+                            "end": 1287
                           }
                         }
                       },
                       "span": {
                         "dummy": false,
-                        "start": 1186,
-                        "end": 1239
+                        "start": 1278,
+                        "end": 1279
                       }
                     }
                   },
                   "rhs": {
-                    "StaticAssetConstructor": {
-                      "type": {
-                        "value": "Ada",
-                        "span": {
-                          "dummy": false,
-                          "start": 1242,
-                          "end": 1245
-                        }
-                      },
-                      "amount": {
-                        "Number": 40
-                      },
+                    "MinUtxo": {
+                      "value": "named_output",
                       "span": {
                         "dummy": false,
-                        "start": 1242,
-                        "end": 1249
+                        "start": 1299,
+                        "end": 1311
                       }
                     }
                   },
                   "span": {
                     "dummy": false,
-                    "start": 1240,
-                    "end": 1241
+                    "start": 1288,
+                    "end": 1289
                   }
                 }
               }
@@ -585,8 +630,8 @@
           ],
           "span": {
             "dummy": false,
-            "start": 964,
-            "end": 1256
+            "start": 989,
+            "end": 1319
           }
         }
       ],
@@ -603,8 +648,8 @@
                 "value": "validUntil",
                 "span": {
                   "dummy": false,
-                  "start": 1434,
-                  "end": 1444
+                  "start": 1497,
+                  "end": 1507
                 }
               }
             }
@@ -612,8 +657,8 @@
         ],
         "span": {
           "dummy": false,
-          "start": 1368,
-          "end": 1451
+          "start": 1431,
+          "end": 1514
         }
       },
       "mints": [
@@ -626,8 +671,8 @@
                     "value": "StaticAsset",
                     "span": {
                       "dummy": false,
-                      "start": 814,
-                      "end": 825
+                      "start": 839,
+                      "end": 850
                     }
                   },
                   "amount": {
@@ -635,8 +680,8 @@
                   },
                   "span": {
                     "dummy": false,
-                    "start": 814,
-                    "end": 830
+                    "start": 839,
+                    "end": 855
                   }
                 }
               }
@@ -647,8 +692,8 @@
           ],
           "span": {
             "dummy": false,
-            "start": 791,
-            "end": 859
+            "start": 816,
+            "end": 884
           }
         },
         {
@@ -661,8 +706,8 @@
                       "value": "AB11223344",
                       "span": {
                         "dummy": false,
-                        "start": 897,
-                        "end": 909
+                        "start": 922,
+                        "end": 934
                       }
                     }
                   },
@@ -671,8 +716,8 @@
                       "value": "OTHER_TOKEN",
                       "span": {
                         "dummy": false,
-                        "start": 911,
-                        "end": 924
+                        "start": 936,
+                        "end": 949
                       }
                     }
                   },
@@ -681,8 +726,8 @@
                   },
                   "span": {
                     "dummy": false,
-                    "start": 888,
-                    "end": 929
+                    "start": 913,
+                    "end": 954
                   }
                 }
               }
@@ -693,8 +738,8 @@
           ],
           "span": {
             "dummy": false,
-            "start": 865,
-            "end": 958
+            "start": 890,
+            "end": 983
           }
         }
       ],
@@ -706,8 +751,8 @@
               "value": "MyParty",
               "span": {
                 "dummy": false,
-                "start": 1280,
-                "end": 1287
+                "start": 1343,
+                "end": 1350
               }
             }
           },
@@ -716,23 +761,23 @@
               "value": "0F5B22E57FEEB5B4FD1D501B007A427C56A76884D4978FAFEF979D9C",
               "span": {
                 "dummy": false,
-                "start": 1297,
-                "end": 1355
+                "start": 1360,
+                "end": 1418
               }
             }
           }
         ],
         "span": {
           "dummy": false,
-          "start": 1262,
-          "end": 1362
+          "start": 1325,
+          "end": 1425
         }
       },
       "adhoc": [],
       "span": {
         "dummy": false,
         "start": 463,
-        "end": 1496
+        "end": 1559
       },
       "collateral": [],
       "metadata": {
@@ -746,22 +791,22 @@
                 "value": "metadata",
                 "span": {
                   "dummy": false,
-                  "start": 1479,
-                  "end": 1487
+                  "start": 1542,
+                  "end": 1550
                 }
               }
             },
             "span": {
               "dummy": false,
-              "start": 1476,
-              "end": 1487
+              "start": 1539,
+              "end": 1550
             }
           }
         ],
         "span": {
           "dummy": false,
-          "start": 1457,
-          "end": 1494
+          "start": 1520,
+          "end": 1557
         }
       }
     }
@@ -1112,6 +1157,6 @@
   "span": {
     "dummy": false,
     "start": 0,
-    "end": 1497
+    "end": 1560
   }
 }

--- a/examples/lang_tour.my_tx.tir
+++ b/examples/lang_tour.my_tx.tir
@@ -20,20 +20,33 @@
                 }
               },
               "min_amount": {
-                "Assets": [
-                  {
-                    "policy": "None",
-                    "asset_name": "None",
-                    "amount": {
-                      "EvalParam": {
-                        "ExpectValue": [
-                          "quantity",
-                          "Int"
-                        ]
+                "EvalBuiltIn": {
+                  "Add": [
+                    {
+                      "Assets": [
+                        {
+                          "policy": "None",
+                          "asset_name": "None",
+                          "amount": {
+                            "EvalParam": {
+                              "ExpectValue": [
+                                "quantity",
+                                "Int"
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "EvalCompiler": {
+                        "ComputeMinUtxo": {
+                          "Number": 0
+                        }
                       }
                     }
-                  }
-                ]
+                  ]
+                }
               },
               "ref": "None",
               "many": false,
@@ -145,20 +158,33 @@
                                 }
                               },
                               "min_amount": {
-                                "Assets": [
-                                  {
-                                    "policy": "None",
-                                    "asset_name": "None",
-                                    "amount": {
-                                      "EvalParam": {
-                                        "ExpectValue": [
-                                          "quantity",
-                                          "Int"
-                                        ]
+                                "EvalBuiltIn": {
+                                  "Add": [
+                                    {
+                                      "Assets": [
+                                        {
+                                          "policy": "None",
+                                          "asset_name": "None",
+                                          "amount": {
+                                            "EvalParam": {
+                                              "ExpectValue": [
+                                                "quantity",
+                                                "Int"
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "EvalCompiler": {
+                                        "ComputeMinUtxo": {
+                                          "Number": 0
+                                        }
                                       }
                                     }
-                                  }
-                                ]
+                                  ]
+                                }
                               },
                               "ref": "None",
                               "many": false,
@@ -203,20 +229,33 @@
                                     }
                                   },
                                   "min_amount": {
-                                    "Assets": [
-                                      {
-                                        "policy": "None",
-                                        "asset_name": "None",
-                                        "amount": {
-                                          "EvalParam": {
-                                            "ExpectValue": [
-                                              "quantity",
-                                              "Int"
-                                            ]
+                                    "EvalBuiltIn": {
+                                      "Add": [
+                                        {
+                                          "Assets": [
+                                            {
+                                              "policy": "None",
+                                              "asset_name": "None",
+                                              "amount": {
+                                                "EvalParam": {
+                                                  "ExpectValue": [
+                                                    "quantity",
+                                                    "Int"
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "EvalCompiler": {
+                                            "ComputeMinUtxo": {
+                                              "Number": 0
+                                            }
                                           }
                                         }
-                                      }
-                                    ]
+                                      ]
+                                    }
                                   },
                                   "ref": "None",
                                   "many": false,
@@ -240,162 +279,214 @@
         "EvalBuiltIn": {
           "Add": [
             {
-              "Assets": [
-                {
-                  "policy": {
-                    "EvalBuiltIn": {
-                      "Property": [
-                        {
-                          "EvalCoerce": {
-                            "IntoAssets": {
-                              "EvalParam": {
-                                "ExpectInput": [
-                                  "source",
-                                  {
-                                    "address": {
-                                      "EvalParam": {
-                                        "ExpectValue": [
-                                          "myparty",
-                                          "Address"
-                                        ]
-                                      }
-                                    },
-                                    "min_amount": {
-                                      "Assets": [
+              "EvalBuiltIn": {
+                "Add": [
+                  {
+                    "Assets": [
+                      {
+                        "policy": {
+                          "EvalBuiltIn": {
+                            "Property": [
+                              {
+                                "EvalCoerce": {
+                                  "IntoAssets": {
+                                    "EvalParam": {
+                                      "ExpectInput": [
+                                        "source",
                                         {
-                                          "policy": "None",
-                                          "asset_name": "None",
-                                          "amount": {
+                                          "address": {
                                             "EvalParam": {
                                               "ExpectValue": [
-                                                "quantity",
-                                                "Int"
+                                                "myparty",
+                                                "Address"
                                               ]
                                             }
-                                          }
+                                          },
+                                          "min_amount": {
+                                            "EvalBuiltIn": {
+                                              "Add": [
+                                                {
+                                                  "Assets": [
+                                                    {
+                                                      "policy": "None",
+                                                      "asset_name": "None",
+                                                      "amount": {
+                                                        "EvalParam": {
+                                                          "ExpectValue": [
+                                                            "quantity",
+                                                            "Int"
+                                                          ]
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "EvalCompiler": {
+                                                    "ComputeMinUtxo": {
+                                                      "Number": 0
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "ref": "None",
+                                          "many": false,
+                                          "collateral": false
                                         }
                                       ]
-                                    },
-                                    "ref": "None",
-                                    "many": false,
-                                    "collateral": false
+                                    }
                                   }
-                                ]
-                              }
-                            }
+                                }
+                              },
+                              2
+                            ]
                           }
                         },
-                        2
-                      ]
-                    }
+                        "asset_name": {
+                          "EvalBuiltIn": {
+                            "Property": [
+                              {
+                                "EvalCoerce": {
+                                  "IntoAssets": {
+                                    "EvalParam": {
+                                      "ExpectInput": [
+                                        "source",
+                                        {
+                                          "address": {
+                                            "EvalParam": {
+                                              "ExpectValue": [
+                                                "myparty",
+                                                "Address"
+                                              ]
+                                            }
+                                          },
+                                          "min_amount": {
+                                            "EvalBuiltIn": {
+                                              "Add": [
+                                                {
+                                                  "Assets": [
+                                                    {
+                                                      "policy": "None",
+                                                      "asset_name": "None",
+                                                      "amount": {
+                                                        "EvalParam": {
+                                                          "ExpectValue": [
+                                                            "quantity",
+                                                            "Int"
+                                                          ]
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "EvalCompiler": {
+                                                    "ComputeMinUtxo": {
+                                                      "Number": 0
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "ref": "None",
+                                          "many": false,
+                                          "collateral": false
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              1
+                            ]
+                          }
+                        },
+                        "amount": {
+                          "EvalBuiltIn": {
+                            "Property": [
+                              {
+                                "EvalCoerce": {
+                                  "IntoAssets": {
+                                    "EvalParam": {
+                                      "ExpectInput": [
+                                        "source",
+                                        {
+                                          "address": {
+                                            "EvalParam": {
+                                              "ExpectValue": [
+                                                "myparty",
+                                                "Address"
+                                              ]
+                                            }
+                                          },
+                                          "min_amount": {
+                                            "EvalBuiltIn": {
+                                              "Add": [
+                                                {
+                                                  "Assets": [
+                                                    {
+                                                      "policy": "None",
+                                                      "asset_name": "None",
+                                                      "amount": {
+                                                        "EvalParam": {
+                                                          "ExpectValue": [
+                                                            "quantity",
+                                                            "Int"
+                                                          ]
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "EvalCompiler": {
+                                                    "ComputeMinUtxo": {
+                                                      "Number": 0
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "ref": "None",
+                                          "many": false,
+                                          "collateral": false
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              0
+                            ]
+                          }
+                        }
+                      }
+                    ]
                   },
-                  "asset_name": {
-                    "EvalBuiltIn": {
-                      "Property": [
-                        {
-                          "EvalCoerce": {
-                            "IntoAssets": {
-                              "EvalParam": {
-                                "ExpectInput": [
-                                  "source",
-                                  {
-                                    "address": {
-                                      "EvalParam": {
-                                        "ExpectValue": [
-                                          "myparty",
-                                          "Address"
-                                        ]
-                                      }
-                                    },
-                                    "min_amount": {
-                                      "Assets": [
-                                        {
-                                          "policy": "None",
-                                          "asset_name": "None",
-                                          "amount": {
-                                            "EvalParam": {
-                                              "ExpectValue": [
-                                                "quantity",
-                                                "Int"
-                                              ]
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "ref": "None",
-                                    "many": false,
-                                    "collateral": false
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        },
-                        1
-                      ]
-                    }
-                  },
-                  "amount": {
-                    "EvalBuiltIn": {
-                      "Property": [
-                        {
-                          "EvalCoerce": {
-                            "IntoAssets": {
-                              "EvalParam": {
-                                "ExpectInput": [
-                                  "source",
-                                  {
-                                    "address": {
-                                      "EvalParam": {
-                                        "ExpectValue": [
-                                          "myparty",
-                                          "Address"
-                                        ]
-                                      }
-                                    },
-                                    "min_amount": {
-                                      "Assets": [
-                                        {
-                                          "policy": "None",
-                                          "asset_name": "None",
-                                          "amount": {
-                                            "EvalParam": {
-                                              "ExpectValue": [
-                                                "quantity",
-                                                "Int"
-                                              ]
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "ref": "None",
-                                    "many": false,
-                                    "collateral": false
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        },
-                        0
-                      ]
-                    }
+                  {
+                    "Assets": [
+                      {
+                        "policy": "None",
+                        "asset_name": "None",
+                        "amount": {
+                          "Number": 40
+                        }
+                      }
+                    ]
                   }
-                }
-              ]
+                ]
+              }
             },
             {
-              "Assets": [
-                {
-                  "policy": "None",
-                  "asset_name": "None",
-                  "amount": {
-                    "Number": 40
-                  }
+              "EvalCompiler": {
+                "ComputeMinUtxo": {
+                  "Number": 0
                 }
-              ]
+              }
             }
           ]
         }

--- a/examples/lang_tour.tx3
+++ b/examples/lang_tour.tx3
@@ -39,7 +39,7 @@ tx my_tx(
     input source {
         from: MyParty,
         datum_is: MyRecord,
-        min_amount: Ada(quantity),
+        min_amount: Ada(quantity) + min_utxo(named_output),
         redeemer: MyVariant::Case1 {
             field1: field_a,
             field2: 0xAFAFAF,
@@ -57,7 +57,7 @@ tx my_tx(
         redeemer: (),
     }
 
-    output {
+    output named_output {
         to: MyParty,
         datum: MyRecord {
             field1: quantity,
@@ -65,7 +65,7 @@ tx my_tx(
             field4: [1, 2, 3, source.field1],
             ...source
         },
-        amount: AnyAsset(source.field3, source.field2, source.field1) + Ada(40),
+        amount: AnyAsset(source.field3, source.field2, source.field1) + Ada(40) + min_utxo(named_output),
     }
 
     signers {

--- a/examples/min_utxo.transfer_min.tir
+++ b/examples/min_utxo.transfer_min.tir
@@ -1,0 +1,174 @@
+{
+  "fees": {
+    "EvalParam": "ExpectFees"
+  },
+  "references": [],
+  "inputs": [
+    {
+      "name": "source",
+      "utxos": {
+        "EvalParam": {
+          "ExpectInput": [
+            "source",
+            {
+              "address": {
+                "EvalParam": {
+                  "ExpectValue": [
+                    "sender",
+                    "Address"
+                  ]
+                }
+              },
+              "min_amount": {
+                "EvalBuiltIn": {
+                  "Add": [
+                    {
+                      "EvalBuiltIn": {
+                        "Add": [
+                          {
+                            "EvalParam": "ExpectFees"
+                          },
+                          {
+                            "EvalCompiler": {
+                              "ComputeMinUtxo": {
+                                "Number": 0
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "EvalCompiler": {
+                        "ComputeMinUtxo": {
+                          "Number": 1
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "ref": "None",
+              "many": false,
+              "collateral": false
+            }
+          ]
+        }
+      },
+      "redeemer": "None"
+    }
+  ],
+  "outputs": [
+    {
+      "address": {
+        "EvalParam": {
+          "ExpectValue": [
+            "receiver",
+            "Address"
+          ]
+        }
+      },
+      "datum": "None",
+      "amount": {
+        "EvalCompiler": {
+          "ComputeMinUtxo": {
+            "Number": 0
+          }
+        }
+      }
+    },
+    {
+      "address": {
+        "EvalParam": {
+          "ExpectValue": [
+            "sender",
+            "Address"
+          ]
+        }
+      },
+      "datum": "None",
+      "amount": {
+        "EvalBuiltIn": {
+          "Sub": [
+            {
+              "EvalBuiltIn": {
+                "Sub": [
+                  {
+                    "EvalCoerce": {
+                      "IntoAssets": {
+                        "EvalParam": {
+                          "ExpectInput": [
+                            "source",
+                            {
+                              "address": {
+                                "EvalParam": {
+                                  "ExpectValue": [
+                                    "sender",
+                                    "Address"
+                                  ]
+                                }
+                              },
+                              "min_amount": {
+                                "EvalBuiltIn": {
+                                  "Add": [
+                                    {
+                                      "EvalBuiltIn": {
+                                        "Add": [
+                                          {
+                                            "EvalParam": "ExpectFees"
+                                          },
+                                          {
+                                            "EvalCompiler": {
+                                              "ComputeMinUtxo": {
+                                                "Number": 0
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "EvalCompiler": {
+                                        "ComputeMinUtxo": {
+                                          "Number": 1
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "ref": "None",
+                              "many": false,
+                              "collateral": false
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "EvalParam": "ExpectFees"
+                  }
+                ]
+              }
+            },
+            {
+              "EvalCompiler": {
+                "ComputeMinUtxo": {
+                  "Number": 0
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "validity": null,
+  "mints": [],
+  "burns": [],
+  "adhoc": [],
+  "collateral": [],
+  "signers": null,
+  "metadata": []
+}

--- a/examples/min_utxo.tx3
+++ b/examples/min_utxo.tx3
@@ -1,0 +1,21 @@
+party Sender;
+party Receiver;
+
+tx transfer_min(
+    quantity: Int
+) {
+    input source {
+        from: Sender,
+        min_amount: fees + min_utxo(minimal_utxo) + min_utxo(change),
+    }
+
+    output minimal_utxo {
+        to: Receiver,
+        amount: min_utxo(minimal_utxo),
+    }
+
+    output change {
+      to: Sender,
+      amount: source - fees - min_utxo(minimal_utxo),
+    }
+}

--- a/examples/vesting.ast
+++ b/examples/vesting.ast
@@ -99,7 +99,14 @@
       ],
       "outputs": [
         {
-          "name": "target",
+          "name": {
+            "value": "target",
+            "span": {
+              "dummy": false,
+              "start": 330,
+              "end": 336
+            }
+          },
           "fields": [
             {
               "To": {
@@ -472,7 +479,14 @@
       ],
       "outputs": [
         {
-          "name": "target",
+          "name": {
+            "value": "target",
+            "span": {
+              "dummy": false,
+              "start": 918,
+              "end": 924
+            }
+          },
           "fields": [
             {
               "To": {


### PR DESCRIPTION
This pull request introduces functionality for computing the minimum UTXO (Unspent Transaction Output) value in compliance with the Cardano CIP-55 specification. It includes changes to support this feature across multiple modules, such as the compiler, language analysis, and lowering processes. Additionally, it adds tests to validate the new functionality.

### Key Changes:

#### Compiler Enhancements:
* Added `compute_min_utxo` function in `crates/tx3-cardano/src/compile/mod.rs` for calculating minimum UTXO value based on transaction body and protocol parameters.
* Updated `Compiler` struct in `crates/tx3-cardano/src/lib.rs` to include `latest_tx_body` for tracking the most recent transaction body.
* Introduced a new compiler operation, `ComputeMinUtxo`, to evaluate minimum UTXO expressions.

#### Language Analysis:
* Enhanced `analyzing.rs` to support `min_utxo` expressions, including tracking outputs and resolving their references. 
* Added tests to validate proper analysis of `min_utxo` expressions and error handling for undefined outputs.

#### Lowering and Parsing:
* Extended `lowering.rs` to convert `min_utxo` expressions into compiler operations during the lowering phase.
* Updated `parsing.rs` to parse named outputs as identifiers, enabling their use in `min_utxo` expressions.

#### Tests:
* Added unit tests in `crates/tx3-cardano/src/tests.rs` and `crates/tx3-lang/src/applying.rs` to verify the correctness of `min_utxo` calculations and ensure non-reduction behavior in arithmetic operations involving `min_utxo`. 

#### Miscellaneous:
* Introduced `MIN_UTXO_BYTES` constant and updated related structures to support the computation.
* Added a new symbol type `Output` in `ast.rs` to represent named outputs.
