### PR TITLE
WIP - feat: Support hashed datum options for inputs and outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,6 @@ target/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 .scratchpad/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,8 +986,7 @@ checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 [[package]]
 name = "pallas"
 version = "1.0.0-alpha.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94c49f12ad9af4277b6d11c4ddc8044975ff1e634b1f5cd696f812eba9ac8f60"
+source = "git+https://github.com/txpipe/pallas.git?rev=065df6542e376761d7b4bc90449493c8880f24c6#065df6542e376761d7b4bc90449493c8880f24c6"
 dependencies = [
  "pallas-addresses",
  "pallas-codec",
@@ -1004,8 +1003,7 @@ dependencies = [
 [[package]]
 name = "pallas-addresses"
 version = "1.0.0-alpha.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f0bf697964d0562ee36727834f3fb698bdcf71dc2fef8c2f15e4e8920c6b55"
+source = "git+https://github.com/txpipe/pallas.git?rev=065df6542e376761d7b4bc90449493c8880f24c6#065df6542e376761d7b4bc90449493c8880f24c6"
 dependencies = [
  "base58",
  "bech32",
@@ -1020,8 +1018,7 @@ dependencies = [
 [[package]]
 name = "pallas-codec"
 version = "1.0.0-alpha.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51205265dc1f976a09e845abb4303e6704de54e377d3350ee30be70b26249f7f"
+source = "git+https://github.com/txpipe/pallas.git?rev=065df6542e376761d7b4bc90449493c8880f24c6#065df6542e376761d7b4bc90449493c8880f24c6"
 dependencies = [
  "hex",
  "minicbor",
@@ -1032,8 +1029,7 @@ dependencies = [
 [[package]]
 name = "pallas-configs"
 version = "1.0.0-alpha.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b280e2fe5e19e6dcee72d01313e5e754b753760980e5419647fe554e9540c739"
+source = "git+https://github.com/txpipe/pallas.git?rev=065df6542e376761d7b4bc90449493c8880f24c6#065df6542e376761d7b4bc90449493c8880f24c6"
 dependencies = [
  "base64 0.22.1",
  "num-rational",
@@ -1048,13 +1044,12 @@ dependencies = [
 [[package]]
 name = "pallas-crypto"
 version = "1.0.0-alpha.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d62094c2f70164cd878b4f3ae2f81f79aca79d7b3a2a5db2fa15d09002d5f7d"
+source = "git+https://github.com/txpipe/pallas.git?rev=065df6542e376761d7b4bc90449493c8880f24c6#065df6542e376761d7b4bc90449493c8880f24c6"
 dependencies = [
  "cryptoxide",
  "hex",
  "pallas-codec",
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
  "serde",
  "thiserror 1.0.69",
 ]
@@ -1062,8 +1057,7 @@ dependencies = [
 [[package]]
 name = "pallas-network"
 version = "1.0.0-alpha.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689a470fe83eb0bc02014681a55614d183c8e339cae3126fcbe8a40cdad23aaf"
+source = "git+https://github.com/txpipe/pallas.git?rev=065df6542e376761d7b4bc90449493c8880f24c6#065df6542e376761d7b4bc90449493c8880f24c6"
 dependencies = [
  "byteorder",
  "hex",
@@ -1080,8 +1074,7 @@ dependencies = [
 [[package]]
 name = "pallas-primitives"
 version = "1.0.0-alpha.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db6f5bff8e1163e33dd116814c7288866928219cb84c90803f41b2d3ec0edc1"
+source = "git+https://github.com/txpipe/pallas.git?rev=065df6542e376761d7b4bc90449493c8880f24c6#065df6542e376761d7b4bc90449493c8880f24c6"
 dependencies = [
  "hex",
  "pallas-codec",
@@ -1093,8 +1086,7 @@ dependencies = [
 [[package]]
 name = "pallas-traverse"
 version = "1.0.0-alpha.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9121e2b43a76b06331e5527c2948da2eef5731f84499e5a3d737a62c7d96f6a"
+source = "git+https://github.com/txpipe/pallas.git?rev=065df6542e376761d7b4bc90449493c8880f24c6#065df6542e376761d7b4bc90449493c8880f24c6"
 dependencies = [
  "hex",
  "itertools 0.13.0",
@@ -1110,8 +1102,7 @@ dependencies = [
 [[package]]
 name = "pallas-txbuilder"
 version = "1.0.0-alpha.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0653ba4617846e812760f293aa339a27fcb957b595f2083da7887b1c094d33c"
+source = "git+https://github.com/txpipe/pallas.git?rev=065df6542e376761d7b4bc90449493c8880f24c6#065df6542e376761d7b4bc90449493c8880f24c6"
 dependencies = [
  "hex",
  "pallas-addresses",
@@ -1127,8 +1118,7 @@ dependencies = [
 [[package]]
 name = "pallas-utxorpc"
 version = "1.0.0-alpha.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feeb18eb3e249116a933dc33bfff11b93f58776e2ce81d06239eda612d22f23e"
+source = "git+https://github.com/txpipe/pallas.git?rev=065df6542e376761d7b4bc90449493c8880f24c6#065df6542e376761d7b4bc90449493c8880f24c6"
 dependencies = [
  "pallas-codec",
  "pallas-crypto",
@@ -1136,14 +1126,13 @@ dependencies = [
  "pallas-traverse",
  "pallas-validate",
  "prost-types",
- "utxorpc-spec 0.16.0",
+ "utxorpc-spec 0.17.0",
 ]
 
 [[package]]
 name = "pallas-validate"
 version = "1.0.0-alpha.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "840a71496d6b9255972cbab9a3ba9c16b07b74773f39767bec90420b99c0a389"
+source = "git+https://github.com/txpipe/pallas.git?rev=065df6542e376761d7b4bc90449493c8880f24c6#065df6542e376761d7b4bc90449493c8880f24c6"
 dependencies = [
  "chrono",
  "hex",
@@ -2251,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "utxorpc-spec"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7148c5cd211c397a41245cfbd8d4cb8371d748ed5e3cf131ebcd9cacfa794206"
+checksum = "a1d984ee351b308377e118135e638a5d544fdb0855f12a3b088d9dcaf0432052"
 dependencies = [
  "bytes",
  "futures-core",

--- a/crates/tx3-cardano/Cargo.toml
+++ b/crates/tx3-cardano/Cargo.toml
@@ -13,9 +13,9 @@ homepage.workspace = true
 readme.workspace = true
 
 [dependencies]
-pallas = { version = ">=1.0.0-alpha, <2.0.0" }
+# pallas = { version = ">=1.0.0-alpha, <2.0.0" }
 # pallas = { version = ">=1.0.0-alpha, <2.0.0", path = "../../../../txpipe/pallas/pallas" }
-# pallas = { git = "https://github.com/txpipe/pallas.git" }
+pallas = { git = "https://github.com/txpipe/pallas.git", rev = "065df6542e376761d7b4bc90449493c8880f24c6" }
 
 hex = "0.4.3"
 thiserror = "2.0.11"

--- a/crates/tx3-cardano/src/tests.rs
+++ b/crates/tx3-cardano/src/tests.rs
@@ -299,6 +299,42 @@ async fn input_datum_test() {
 }
 
 #[pollster::test]
+async fn input_hashed_datum_test() {
+    let mut compiler = test_compiler(None);
+
+    let utxos = wildcard_utxos(Some(tx3_lang::ir::Expression::Struct(
+        tx3_lang::ir::StructExpr {
+            constructor: 0,
+            fields: vec![
+                tx3_lang::ir::Expression::Number(1),
+                tx3_lang::ir::Expression::Bytes(b"abc".to_vec()),
+            ],
+        },
+    )));
+
+    let protocol = load_protocol("input_hashed_datum");
+
+    let mut tx = protocol
+        .new_tx("increase_counter")
+        .unwrap()
+        .apply()
+        .unwrap();
+
+    tx.set_arg("myparty", address_to_bytes("addr1qx0rs5qrvx9qkndwu0w88t0xghgy3f53ha76kpx8uf496m9rn2ursdm3r0fgf5pmm4lpufshl8lquk5yykg4pd00hp6quf2hh2"));
+
+    let tx = tx.apply().unwrap();
+
+    let tx = test_compile(tx.into(), &mut compiler, utxos);
+
+    println!("{}", hex::encode(tx.payload));
+
+    assert_eq!(
+        hex::encode(tx.hash),
+        "2a9ae249a6be7be3c5e5fc2da72bdb760ca1d507c706fc453a384b0792efecb4"
+    );
+}
+
+#[pollster::test]
 async fn env_vars_test() {
     let mut compiler = test_compiler(None);
     let utxos = wildcard_utxos(None);

--- a/crates/tx3-lang/src/analyzing.rs
+++ b/crates/tx3-lang/src/analyzing.rs
@@ -1009,6 +1009,7 @@ impl Analyzable for OutputBlockField {
             OutputBlockField::To(x) => x.analyze(parent),
             OutputBlockField::Amount(x) => x.analyze(parent),
             OutputBlockField::Datum(x) => x.analyze(parent),
+            OutputBlockField::HashedDatum(x) => x.analyze(parent),
         }
     }
 
@@ -1017,6 +1018,7 @@ impl Analyzable for OutputBlockField {
             OutputBlockField::To(x) => x.is_resolved(),
             OutputBlockField::Amount(x) => x.is_resolved(),
             OutputBlockField::Datum(x) => x.is_resolved(),
+            OutputBlockField::HashedDatum(x) => x.is_resolved(),
         }
     }
 }

--- a/crates/tx3-lang/src/applying.rs
+++ b/crates/tx3-lang/src/applying.rs
@@ -1153,6 +1153,7 @@ impl Composite for ir::Output {
         Ok(Self {
             address: f(self.address)?,
             datum: f(self.datum)?,
+            datum_hash_mode: self.datum_hash_mode,
             amount: f(self.amount)?,
             optional: self.optional,
         })

--- a/crates/tx3-lang/src/ast.rs
+++ b/crates/tx3-lang/src/ast.rs
@@ -387,6 +387,7 @@ pub enum OutputBlockField {
     To(Box<DataExpr>),
     Amount(Box<DataExpr>),
     Datum(Box<DataExpr>),
+    HashedDatum(Box<DataExpr>),
 }
 
 impl OutputBlockField {
@@ -395,6 +396,7 @@ impl OutputBlockField {
             OutputBlockField::To(_) => "to",
             OutputBlockField::Amount(_) => "amount",
             OutputBlockField::Datum(_) => "datum",
+            OutputBlockField::HashedDatum(_) => "hashed_datum",
         }
     }
 }

--- a/crates/tx3-lang/src/ir.rs
+++ b/crates/tx3-lang/src/ir.rs
@@ -315,6 +315,7 @@ pub struct Input {
 pub struct Output {
     pub address: Expression,
     pub datum: Expression,
+    pub datum_hash_mode: bool,
     pub amount: Expression,
     pub optional: bool,
 }
@@ -536,6 +537,7 @@ impl Node for Output {
         let visited = Self {
             address: self.address.apply(visitor)?,
             datum: self.datum.apply(visitor)?,
+            datum_hash_mode: self.datum_hash_mode,
             amount: self.amount.apply(visitor)?,
             optional: self.optional,
         };

--- a/crates/tx3-lang/src/parsing.rs
+++ b/crates/tx3-lang/src/parsing.rs
@@ -569,6 +569,11 @@ impl AstNode for OutputBlockField {
                 let x = OutputBlockField::Datum(DataExpr::parse(pair)?.into());
                 Ok(x)
             }
+            Rule::output_block_hashed_datum => {
+                let pair = pair.into_inner().next().unwrap();
+                let x = OutputBlockField::HashedDatum(DataExpr::parse(pair)?.into());
+                Ok(x)
+            }
             x => unreachable!("Unexpected rule in output_block_field: {:?}", x),
         }
     }
@@ -578,6 +583,7 @@ impl AstNode for OutputBlockField {
             Self::To(x) => x.span(),
             Self::Amount(x) => x.span(),
             Self::Datum(x) => x.span(),
+            Self::HashedDatum(x) => x.span(),
         }
     }
 }

--- a/crates/tx3-lang/src/tx3.pest
+++ b/crates/tx3-lang/src/tx3.pest
@@ -259,11 +259,13 @@ reference_block = {
 output_block_to = { "to" ~ ":" ~ data_expr }
 output_block_amount = { "amount" ~ ":" ~ data_expr }
 output_block_datum = { "datum" ~ ":" ~ data_expr }
+output_block_hashed_datum = { "hashed_datum" ~ ":" ~ data_expr }
 
 output_block_field = _{
     output_block_to |
     output_block_amount |
-    output_block_datum
+    output_block_datum |
+    output_block_hashed_datum
 }
 
 output_block = {

--- a/examples/input_hashed_datum.tx3
+++ b/examples/input_hashed_datum.tx3
@@ -1,0 +1,29 @@
+type MyRecord {
+    counter: Int,
+    other_field: Bytes,
+}
+
+party MyParty;
+
+tx increase_counter() {
+    input source {
+        from: MyParty,
+        min_amount: fees,
+        datum_is: MyRecord,
+    }
+
+    output {
+        to: MyParty,
+        amount: source - fees,
+
+// FIXME: We can't seem to reference source fields here yet.
+//        hashed_datum: MyRecord {
+//            counter: source.counter + 1,
+//            other_field: source.other_field,
+//
+        hashed_datum: MyRecord {
+            counter: 2,
+            other_field: "abc",
+        },
+    }
+}


### PR DESCRIPTION
This PR has a basic framework for creating an output that only has a datum hash and not inline datum.  However, it's stuck in that I can't seem to reference source fields.

~~The other issue is in Pallas: https://github.com/txpipe/pallas/issues/711~~

~~The test transaction that gets built has no script datum hash value because there are no redeemers. This is an incorrect behavior of pallas.~~