### PR TITLE
Cardano publish block coercion

### DIFF
--- a/crates/tx3-lang/src/cardano.rs
+++ b/crates/tx3-lang/src/cardano.rs
@@ -711,9 +711,18 @@ impl IntoLower for CardanoPublishBlockField {
         ctx: &crate::lowering::Context,
     ) -> Result<Self::Output, crate::lowering::Error> {
         match self {
-            CardanoPublishBlockField::To(x) => Ok(("to".to_string(), x.into_lower(ctx)?)),
-            CardanoPublishBlockField::Amount(x) => Ok(("amount".to_string(), x.into_lower(ctx)?)),
-            CardanoPublishBlockField::Datum(x) => Ok(("datum".to_string(), x.into_lower(ctx)?)),
+            CardanoPublishBlockField::To(x) => {
+                let ctx = ctx.enter_address_expr();
+                Ok(("to".to_string(), x.into_lower(&ctx)?))
+            }
+            CardanoPublishBlockField::Amount(x) => {
+                let ctx = ctx.enter_asset_expr();
+                Ok(("amount".to_string(), x.into_lower(&ctx)?))
+            }
+            CardanoPublishBlockField::Datum(x) => {
+                let ctx = ctx.enter_datum_expr();
+                Ok(("datum".to_string(), x.into_lower(&ctx)?))
+            }
             CardanoPublishBlockField::Version(x) => Ok(("version".to_string(), x.into_lower(ctx)?)),
             CardanoPublishBlockField::Script(x) => Ok(("script".to_string(), x.into_lower(ctx)?)),
         }


### PR DESCRIPTION
This pull request refines the lowering process for Cardano block publishing by introducing more context-aware transformations for specific fields. The main improvement is that each field (`To`, `Amount`, and `Datum`) now uses a specialized context when being lowered, which should help ensure correctness and clarity in how these fields are processed.

Enhancements to context handling during lowering:

* The `To` field now uses `ctx.enter_address_expr()` to provide an address-specific context before lowering.
* The `Amount` field now uses `ctx.enter_asset_expr()` to provide an asset-specific context before lowering.
* The `Datum` field now uses `ctx.enter_datum_expr()` to provide a datum-specific context before lowering.