### PR TITLE
feat: min_utxo op supports cardano::publish blocks

### DIFF
--- a/crates/tx3-cardano/src/tests.rs
+++ b/crates/tx3-cardano/src/tests.rs
@@ -524,3 +524,23 @@ async fn min_utxo_compiler_op_test() {
         assert!(!assets.is_empty());
     }
 }
+
+#[pollster::test]
+async fn cardano_publish_min_utxo_test() {
+    let mut compiler = test_compiler(None);
+    let utxos = wildcard_utxos(None);
+    let protocol = load_protocol("cardano_publish_min_utxo");
+
+    let tx = protocol.tir("test_min_utxo_publish").unwrap().clone();
+
+    let args = BTreeMap::from([]);
+
+    let tx = test_compile(tx, &args, &mut compiler, utxos);
+
+    println!("{}", hex::encode(tx.payload));
+
+    assert_eq!(
+        hex::encode(tx.hash),
+        "2da0a42d6245f61d595f0acf77df1560fd3e4c5f553737caf606003804ea5014"
+    );
+}

--- a/crates/tx3-lang/src/analyzing.rs
+++ b/crates/tx3-lang/src/analyzing.rs
@@ -1243,8 +1243,21 @@ impl TxDef {
             scope.track_input(&input.name, input.clone())
         }
 
-        for (index, output) in self.outputs.iter().enumerate() {
-            scope.track_output(index, output.clone())
+        for output in self.outputs.iter() {
+            scope.track_output(output.declared_index, output.clone())
+        }
+
+        for adhoc in self.adhoc.iter() {
+            match adhoc {
+                ChainSpecificBlock::Cardano(crate::cardano::CardanoBlock::Publish(pb)) => {
+                    if let Some(n) = &pb.name {
+                        scope
+                            .symbols
+                            .insert(n.value.clone(), Symbol::Output(pb.declared_index));
+                    }
+                }
+                _ => {}
+            }
         }
 
         let scope_snapshot = Rc::new(scope);

--- a/crates/tx3-lang/src/ast.rs
+++ b/crates/tx3-lang/src/ast.rs
@@ -404,7 +404,7 @@ pub struct OutputBlock {
     pub optional: bool,
     pub fields: Vec<OutputBlockField>,
     pub span: Span,
-    pub declared_index: Option<usize>,
+    pub declared_index: usize,
 }
 
 impl OutputBlock {

--- a/crates/tx3-lang/src/ast.rs
+++ b/crates/tx3-lang/src/ast.rs
@@ -404,6 +404,7 @@ pub struct OutputBlock {
     pub optional: bool,
     pub fields: Vec<OutputBlockField>,
     pub span: Span,
+    pub declared_index: Option<usize>,
 }
 
 impl OutputBlock {

--- a/crates/tx3-lang/src/cardano.rs
+++ b/crates/tx3-lang/src/cardano.rs
@@ -740,7 +740,7 @@ impl IntoLower for CardanoPublishBlock {
             .collect::<Result<_, _>>()?;
 
         data.insert(
-            "declared_index".into(),
+            "declared_index".to_string(),
             ir::Expression::Number(
                 self.declared_index
                     .map(|x| x as i128)

--- a/crates/tx3-lang/src/cardano.rs
+++ b/crates/tx3-lang/src/cardano.rs
@@ -586,7 +586,7 @@ pub struct CardanoPublishBlock {
     pub name: Option<Identifier>,
     pub fields: Vec<CardanoPublishBlockField>,
     pub span: Span,
-    pub declared_index: Option<usize>,
+    pub declared_index: usize,
 }
 
 impl CardanoPublishBlock {
@@ -668,7 +668,7 @@ impl AstNode for CardanoPublishBlock {
             name,
             fields,
             span,
-            declared_index: None,
+            declared_index: 0,
         })
     }
 
@@ -750,11 +750,7 @@ impl IntoLower for CardanoPublishBlock {
 
         data.insert(
             "declared_index".to_string(),
-            ir::Expression::Number(
-                self.declared_index
-                    .map(|x| x as i128)
-                    .expect("Publish block must have a declaration index"),
-            ),
+            ir::Expression::Number(self.declared_index as i128),
         );
 
         Ok(ir::AdHocDirective {
@@ -962,7 +958,7 @@ mod tests {
                 ))),
             ],
             span: Span::DUMMY,
-            declared_index: None,
+            declared_index: 0,
         }
     );
 
@@ -992,7 +988,7 @@ mod tests {
                 ))),
             ],
             span: Span::DUMMY,
-            declared_index: None,
+            declared_index: 0,
         }
     );
 

--- a/crates/tx3-lang/src/cardano.rs
+++ b/crates/tx3-lang/src/cardano.rs
@@ -733,11 +733,20 @@ impl IntoLower for CardanoPublishBlock {
         &self,
         ctx: &crate::lowering::Context,
     ) -> Result<Self::Output, crate::lowering::Error> {
-        let data = self
+        let mut data: HashMap<String, ir::Expression> = self
             .fields
             .iter()
             .map(|x| x.into_lower(ctx))
             .collect::<Result<_, _>>()?;
+
+        data.insert(
+            "declared_index".into(),
+            ir::Expression::Number(
+                self.declared_index
+                    .map(|x| x as i128)
+                    .expect("Publish block must have a declaration index"),
+            ),
+        );
 
         Ok(ir::AdHocDirective {
             name: "cardano_publish".to_string(),

--- a/crates/tx3-lang/src/cardano.rs
+++ b/crates/tx3-lang/src/cardano.rs
@@ -586,6 +586,7 @@ pub struct CardanoPublishBlock {
     pub name: Option<Identifier>,
     pub fields: Vec<CardanoPublishBlockField>,
     pub span: Span,
+    pub declared_index: Option<usize>,
 }
 
 impl CardanoPublishBlock {
@@ -663,7 +664,12 @@ impl AstNode for CardanoPublishBlock {
             .map(|x| CardanoPublishBlockField::parse(x))
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(CardanoPublishBlock { name, fields, span })
+        Ok(CardanoPublishBlock {
+            name,
+            fields,
+            span,
+            declared_index: None,
+        })
     }
 
     fn span(&self) -> &Span {
@@ -938,6 +944,7 @@ mod tests {
                 ))),
             ],
             span: Span::DUMMY,
+            declared_index: None,
         }
     );
 
@@ -967,6 +974,7 @@ mod tests {
                 ))),
             ],
             span: Span::DUMMY,
+            declared_index: None,
         }
     );
 

--- a/crates/tx3-lang/src/cardano.rs
+++ b/crates/tx3-lang/src/cardano.rs
@@ -711,9 +711,18 @@ impl IntoLower for CardanoPublishBlockField {
         ctx: &crate::lowering::Context,
     ) -> Result<Self::Output, crate::lowering::Error> {
         match self {
-            CardanoPublishBlockField::To(x) => Ok(("to".to_string(), x.into_lower(ctx)?)),
-            CardanoPublishBlockField::Amount(x) => Ok(("amount".to_string(), x.into_lower(ctx)?)),
-            CardanoPublishBlockField::Datum(x) => Ok(("datum".to_string(), x.into_lower(ctx)?)),
+            CardanoPublishBlockField::To(x) => {
+                let ctx = ctx.enter_address_expr();
+                Ok(("to".to_string(), x.into_lower(&ctx)?))
+            }
+            CardanoPublishBlockField::Amount(x) => {
+                let ctx = ctx.enter_asset_expr();
+                Ok(("amount".to_string(), x.into_lower(&ctx)?))
+            }
+            CardanoPublishBlockField::Datum(x) => {
+                let ctx = ctx.enter_datum_expr();
+                Ok(("datum".to_string(), x.into_lower(&ctx)?))
+            }
             CardanoPublishBlockField::Version(x) => Ok(("version".to_string(), x.into_lower(ctx)?)),
             CardanoPublishBlockField::Script(x) => Ok(("script".to_string(), x.into_lower(ctx)?)),
         }

--- a/crates/tx3-lang/src/lowering.rs
+++ b/crates/tx3-lang/src/lowering.rs
@@ -703,6 +703,7 @@ impl IntoLower for ast::OutputBlock {
             datum,
             amount,
             optional: self.optional,
+            declared_index: self.declared_index.map(|n| n as u32),
         })
     }
 }

--- a/crates/tx3-lang/src/lowering.rs
+++ b/crates/tx3-lang/src/lowering.rs
@@ -697,13 +697,14 @@ impl IntoLower for ast::OutputBlock {
         let address = self.find("to").into_lower(ctx)?.unwrap_or_default();
         let datum = self.find("datum").into_lower(ctx)?.unwrap_or_default();
         let amount = self.find("amount").into_lower(ctx)?.unwrap_or_default();
+        let declared_ix = self.declared_index.unwrap();
 
         Ok(ir::Output {
             address,
             datum,
             amount,
             optional: self.optional,
-            declared_index: self.declared_index,
+            declared_index: ir::Expression::Number(declared_ix as i128),
         })
     }
 }

--- a/crates/tx3-lang/src/lowering.rs
+++ b/crates/tx3-lang/src/lowering.rs
@@ -697,7 +697,7 @@ impl IntoLower for ast::OutputBlock {
         let address = self.find("to").into_lower(ctx)?.unwrap_or_default();
         let datum = self.find("datum").into_lower(ctx)?.unwrap_or_default();
         let amount = self.find("amount").into_lower(ctx)?.unwrap_or_default();
-        let declared_ix = self.declared_index.unwrap();
+        let declared_ix = self.declared_index;
 
         Ok(ir::Output {
             address,

--- a/crates/tx3-lang/src/lowering.rs
+++ b/crates/tx3-lang/src/lowering.rs
@@ -703,7 +703,7 @@ impl IntoLower for ast::OutputBlock {
             datum,
             amount,
             optional: self.optional,
-            declared_index: self.declared_index.map(|n| n as u32),
+            declared_index: self.declared_index,
         })
     }
 }

--- a/crates/tx3-lang/src/parsing.rs
+++ b/crates/tx3-lang/src/parsing.rs
@@ -2836,4 +2836,6 @@ mod tests {
     test_parsing!(list_concat);
 
     test_parsing!(buidler_fest_2026);
+
+    test_parsing!(cardano_publish_min_utxo);
 }

--- a/crates/tx3-lang/src/parsing.rs
+++ b/crates/tx3-lang/src/parsing.rs
@@ -217,7 +217,7 @@ impl AstNode for TxDef {
                 Rule::input_block => inputs.push(InputBlock::parse(item)?),
                 Rule::output_block => {
                     let mut ob = OutputBlock::parse(item)?;
-                    ob.declared_index = Some(declared_index);
+                    ob.declared_index = declared_index;
                     declared_index += 1;
                     outputs.push(ob);
                 }
@@ -228,7 +228,7 @@ impl AstNode for TxDef {
                     let mut csb = ChainSpecificBlock::parse(item)?;
                     let ChainSpecificBlock::Cardano(cardano_block) = &mut csb;
                     if let crate::cardano::CardanoBlock::Publish(pb) = cardano_block {
-                        pb.declared_index = Some(declared_index);
+                        pb.declared_index = declared_index;
                         declared_index += 1;
                     }
 
@@ -633,7 +633,8 @@ impl AstNode for OutputBlock {
             optional,
             fields,
             span,
-            declared_index: None,
+            // Default to 0 and set it later
+            declared_index: 0,
         })
     }
 
@@ -2481,7 +2482,7 @@ mod tests {
                 }))),
             ],
             span: Span::DUMMY,
-            declared_index: None,
+            declared_index: 0,
         }
     );
 

--- a/crates/tx3-tir/src/model/v1beta0.rs
+++ b/crates/tx3-tir/src/model/v1beta0.rs
@@ -305,6 +305,7 @@ pub struct Output {
     pub datum: Expression,
     pub amount: Expression,
     pub optional: bool,
+    pub declared_index: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -522,6 +523,7 @@ impl Node for Output {
             datum: self.datum.apply(visitor)?,
             amount: self.amount.apply(visitor)?,
             optional: self.optional,
+            declared_index: self.declared_index,
         };
 
         Ok(visited)

--- a/crates/tx3-tir/src/model/v1beta0.rs
+++ b/crates/tx3-tir/src/model/v1beta0.rs
@@ -305,7 +305,7 @@ pub struct Output {
     pub datum: Expression,
     pub amount: Expression,
     pub optional: bool,
-    pub declared_index: Option<usize>,
+    pub declared_index: Expression,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/tx3-tir/src/model/v1beta0.rs
+++ b/crates/tx3-tir/src/model/v1beta0.rs
@@ -305,6 +305,7 @@ pub struct Output {
     pub datum: Expression,
     pub amount: Expression,
     pub optional: bool,
+    #[serde(default)]
     pub declared_index: Expression,
 }
 

--- a/crates/tx3-tir/src/model/v1beta0.rs
+++ b/crates/tx3-tir/src/model/v1beta0.rs
@@ -305,7 +305,7 @@ pub struct Output {
     pub datum: Expression,
     pub amount: Expression,
     pub optional: bool,
-    pub declared_index: Option<u32>,
+    pub declared_index: Option<usize>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/tx3-tir/src/reduce/mod.rs
+++ b/crates/tx3-tir/src/reduce/mod.rs
@@ -1159,6 +1159,7 @@ impl Composite for Output {
             datum: f(self.datum)?,
             amount: f(self.amount)?,
             optional: self.optional,
+            declared_index: self.declared_index,
         })
     }
 }

--- a/examples/asteria.ast
+++ b/examples/asteria.ast
@@ -597,7 +597,8 @@
             "dummy": false,
             "start": 1158,
             "end": 1379
-          }
+          },
+          "declared_index": 0
         },
         {
           "name": null,
@@ -651,7 +652,8 @@
             "dummy": false,
             "start": 1385,
             "end": 1449
-          }
+          },
+          "declared_index": 1
         }
       ],
       "validity": null,

--- a/examples/asteria.move_ship.tir
+++ b/examples/asteria.move_ship.tir
@@ -1168,7 +1168,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 0
+      }
     },
     {
       "address": {
@@ -1262,7 +1265,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 1
+      }
     }
   ],
   "validity": null,

--- a/examples/buidler_fest_2026.ast
+++ b/examples/buidler_fest_2026.ast
@@ -537,7 +537,8 @@
             "dummy": false,
             "start": 958,
             "end": 1063
-          }
+          },
+          "declared_index": 0
         },
         {
           "name": {
@@ -672,7 +673,8 @@
             "dummy": false,
             "start": 1069,
             "end": 1246
-          }
+          },
+          "declared_index": 1
         },
         {
           "name": {
@@ -733,7 +735,8 @@
             "dummy": false,
             "start": 1252,
             "end": 1331
-          }
+          },
+          "declared_index": 2
         }
       ],
       "validity": {

--- a/examples/buidler_fest_2026.buy_ticket.tir
+++ b/examples/buidler_fest_2026.buy_ticket.tir
@@ -324,7 +324,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 0
+      }
     },
     {
       "address": {
@@ -458,7 +461,10 @@
           }
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 1
+      }
     },
     {
       "address": {
@@ -486,7 +492,10 @@
           }
         ]
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 2
+      }
     }
   ],
   "validity": {

--- a/examples/burn.ast
+++ b/examples/burn.ast
@@ -222,7 +222,8 @@
             "dummy": false,
             "start": 337,
             "end": 412
-          }
+          },
+          "declared_index": 0
         }
       ],
       "validity": null,

--- a/examples/burn.burn_stuff.tir
+++ b/examples/burn.burn_stuff.tir
@@ -244,7 +244,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 0
+      }
     }
   ],
   "validity": null,

--- a/examples/cardano_publish_min_utxo.ast
+++ b/examples/cardano_publish_min_utxo.ast
@@ -1,0 +1,207 @@
+{
+  "env": null,
+  "txs": [
+    {
+      "name": {
+        "value": "test_min_utxo_publish",
+        "span": {
+          "dummy": false,
+          "start": 3,
+          "end": 24
+        }
+      },
+      "parameters": {
+        "parameters": [],
+        "span": {
+          "dummy": false,
+          "start": 24,
+          "end": 26
+        }
+      },
+      "locals": null,
+      "references": [],
+      "inputs": [],
+      "outputs": [
+        {
+          "name": {
+            "value": "s",
+            "span": {
+              "dummy": false,
+              "start": 267,
+              "end": 268
+            }
+          },
+          "optional": false,
+          "fields": [
+            {
+              "To": {
+                "String": {
+                  "value": "addr1qx0rs5qrvx9qkndwu0w88t0xghgy3f53ha76kpx8uf496m9rn2ursdm3r0fgf5pmm4lpufshl8lquk5yykg4pd00hp6quf2hh2",
+                  "span": {
+                    "dummy": false,
+                    "start": 283,
+                    "end": 388
+                  }
+                }
+              }
+            },
+            {
+              "Amount": {
+                "FnCall": {
+                  "callee": {
+                    "value": "Ada",
+                    "span": {
+                      "dummy": false,
+                      "start": 406,
+                      "end": 409
+                    }
+                  },
+                  "args": [
+                    {
+                      "FnCall": {
+                        "callee": {
+                          "value": "min_utxo",
+                          "span": {
+                            "dummy": false,
+                            "start": 410,
+                            "end": 418
+                          }
+                        },
+                        "args": [
+                          {
+                            "Identifier": {
+                              "value": "my_block",
+                              "span": {
+                                "dummy": false,
+                                "start": 419,
+                                "end": 427
+                              }
+                            }
+                          }
+                        ],
+                        "span": {
+                          "dummy": false,
+                          "start": 410,
+                          "end": 428
+                        }
+                      }
+                    }
+                  ],
+                  "span": {
+                    "dummy": false,
+                    "start": 406,
+                    "end": 429
+                  }
+                }
+              }
+            }
+          ],
+          "span": {
+            "dummy": false,
+            "start": 261,
+            "end": 436
+          },
+          "declared_index": 1
+        }
+      ],
+      "validity": null,
+      "mints": [],
+      "burns": [],
+      "signers": null,
+      "adhoc": [
+        {
+          "Cardano": {
+            "Publish": {
+              "name": {
+                "value": "my_block",
+                "span": {
+                  "dummy": false,
+                  "start": 50,
+                  "end": 58
+                }
+              },
+              "fields": [
+                {
+                  "To": {
+                    "String": {
+                      "value": "addr1qx0rs5qrvx9qkndwu0w88t0xghgy3f53ha76kpx8uf496m9rn2ursdm3r0fgf5pmm4lpufshl8lquk5yykg4pd00hp6quf2hh2",
+                      "span": {
+                        "dummy": false,
+                        "start": 73,
+                        "end": 178
+                      }
+                    }
+                  }
+                },
+                {
+                  "Amount": {
+                    "FnCall": {
+                      "callee": {
+                        "value": "Ada",
+                        "span": {
+                          "dummy": false,
+                          "start": 196,
+                          "end": 199
+                        }
+                      },
+                      "args": [
+                        {
+                          "Number": 100
+                        }
+                      ],
+                      "span": {
+                        "dummy": false,
+                        "start": 196,
+                        "end": 204
+                      }
+                    }
+                  }
+                },
+                {
+                  "Script": {
+                    "HexString": {
+                      "value": "5709",
+                      "span": {
+                        "dummy": false,
+                        "start": 222,
+                        "end": 228
+                      }
+                    }
+                  }
+                },
+                {
+                  "Version": {
+                    "Number": 2
+                  }
+                }
+              ],
+              "span": {
+                "dummy": false,
+                "start": 42,
+                "end": 255
+              },
+              "declared_index": 0
+            }
+          }
+        }
+      ],
+      "span": {
+        "dummy": false,
+        "start": 0,
+        "end": 438
+      },
+      "collateral": [],
+      "metadata": null
+    }
+  ],
+  "types": [],
+  "aliases": [],
+  "assets": [],
+  "parties": [],
+  "policies": [],
+  "span": {
+    "dummy": false,
+    "start": 0,
+    "end": 439
+  }
+}

--- a/examples/cardano_publish_min_utxo.tx3
+++ b/examples/cardano_publish_min_utxo.tx3
@@ -1,0 +1,13 @@
+tx test_min_utxo_publish() {
+    cardano::publish my_block {
+        to: "addr1qx0rs5qrvx9qkndwu0w88t0xghgy3f53ha76kpx8uf496m9rn2ursdm3r0fgf5pmm4lpufshl8lquk5yykg4pd00hp6quf2hh2",
+        amount: Ada(100),
+        script: 0x5709,
+        version: 2,
+    }
+
+    outputs {
+        to: "addr1qx0rs5qrvx9qkndwu0w88t0xghgy3f53ha76kpx8uf496m9rn2ursdm3r0fgf5pmm4lpufshl8lquk5yykg4pd00hp6quf2hh2",
+        amount: Ada(min_utxo(my_block)),
+    }
+}

--- a/examples/cardano_witness.ast
+++ b/examples/cardano_witness.ast
@@ -203,7 +203,8 @@
             "dummy": false,
             "start": 404,
             "end": 481
-          }
+          },
+          "declared_index": 0
         }
       ],
       "validity": null,
@@ -525,7 +526,8 @@
             "dummy": false,
             "start": 972,
             "end": 1049
-          }
+          },
+          "declared_index": 0
         }
       ],
       "validity": null,

--- a/examples/cardano_witness.mint_from_native_script.tir
+++ b/examples/cardano_witness.mint_from_native_script.tir
@@ -134,7 +134,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 0
+      }
     }
   ],
   "validity": null,

--- a/examples/cardano_witness.mint_from_plutus.tir
+++ b/examples/cardano_witness.mint_from_plutus.tir
@@ -134,7 +134,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 0
+      }
     }
   ],
   "validity": null,

--- a/examples/disordered.ast
+++ b/examples/disordered.ast
@@ -160,7 +160,8 @@
             "dummy": false,
             "start": 58,
             "end": 125
-          }
+          },
+          "declared_index": 0
         },
         {
           "name": null,
@@ -252,7 +253,8 @@
             "dummy": false,
             "start": 214,
             "end": 295
-          }
+          },
+          "declared_index": 1
         }
       ],
       "validity": null,

--- a/examples/donation.ast
+++ b/examples/donation.ast
@@ -267,7 +267,8 @@
             "dummy": false,
             "start": 187,
             "end": 286
-          }
+          },
+          "declared_index": 0
         }
       ],
       "validity": null,

--- a/examples/donation.mint_from_plutus.tir
+++ b/examples/donation.mint_from_plutus.tir
@@ -198,7 +198,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 0
+      }
     }
   ],
   "validity": null,

--- a/examples/env_vars.ast
+++ b/examples/env_vars.ast
@@ -170,7 +170,8 @@
             "dummy": false,
             "start": 343,
             "end": 426
-          }
+          },
+          "declared_index": 0
         }
       ],
       "validity": null,

--- a/examples/env_vars.mint_from_env.tir
+++ b/examples/env_vars.mint_from_env.tir
@@ -72,7 +72,10 @@
           }
         ]
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 0
+      }
     }
   ],
   "validity": null,

--- a/examples/faucet.ast
+++ b/examples/faucet.ast
@@ -171,7 +171,8 @@
             "dummy": false,
             "start": 429,
             "end": 523
-          }
+          },
+          "declared_index": 0
         }
       ],
       "validity": null,

--- a/examples/faucet.claim_with_password.tir
+++ b/examples/faucet.claim_with_password.tir
@@ -134,7 +134,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 0
+      }
     }
   ],
   "validity": null,

--- a/examples/input_datum.ast
+++ b/examples/input_datum.ast
@@ -259,7 +259,8 @@
             "dummy": false,
             "start": 208,
             "end": 397
-          }
+          },
+          "declared_index": 0
         }
       ],
       "validity": null,

--- a/examples/input_datum.increase_counter.tir
+++ b/examples/input_datum.increase_counter.tir
@@ -166,7 +166,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 0
+      }
     }
   ],
   "validity": null,

--- a/examples/lang_tour.ast
+++ b/examples/lang_tour.ast
@@ -845,7 +845,8 @@
             "dummy": false,
             "start": 1243,
             "end": 1622
-          }
+          },
+          "declared_index": 0
         }
       ],
       "validity": {

--- a/examples/lang_tour.my_tx.tir
+++ b/examples/lang_tour.my_tx.tir
@@ -648,14 +648,6 @@
     {
       "name": "vote_delegation_certificate",
       "data": {
-        "stake": {
-          "Bytes": [
-            135,
-            101,
-            67,
-            33
-          ]
-        },
         "drep": {
           "Bytes": [
             18,
@@ -663,15 +655,20 @@
             86,
             120
           ]
+        },
+        "stake": {
+          "Bytes": [
+            135,
+            101,
+            67,
+            33
+          ]
         }
       }
     },
     {
       "name": "withdrawal",
       "data": {
-        "amount": {
-          "Number": 100
-        },
         "redeemer": {
           "Struct": {
             "constructor": 0,
@@ -685,15 +682,15 @@
               "Address"
             ]
           }
+        },
+        "amount": {
+          "Number": 100
         }
       }
     },
     {
       "name": "plutus_witness",
       "data": {
-        "version": {
-          "Number": 2
-        },
         "script": {
           "Bytes": [
             171,
@@ -702,6 +699,9 @@
             18,
             52
           ]
+        },
+        "version": {
+          "Number": 2
         }
       }
     },

--- a/examples/lang_tour.my_tx.tir
+++ b/examples/lang_tour.my_tx.tir
@@ -534,7 +534,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 0
+      }
     }
   ],
   "validity": {
@@ -669,6 +672,12 @@
         "amount": {
           "Number": 100
         },
+        "redeemer": {
+          "Struct": {
+            "constructor": 0,
+            "fields": []
+          }
+        },
         "credential": {
           "EvalParam": {
             "ExpectValue": [
@@ -676,18 +685,15 @@
               "Address"
             ]
           }
-        },
-        "redeemer": {
-          "Struct": {
-            "constructor": 0,
-            "fields": []
-          }
         }
       }
     },
     {
       "name": "plutus_witness",
       "data": {
+        "version": {
+          "Number": 2
+        },
         "script": {
           "Bytes": [
             171,
@@ -696,9 +702,6 @@
             18,
             52
           ]
-        },
-        "version": {
-          "Number": 2
         }
       }
     },

--- a/examples/list_concat.ast
+++ b/examples/list_concat.ast
@@ -214,7 +214,8 @@
             "dummy": false,
             "start": 156,
             "end": 303
-          }
+          },
+          "declared_index": 0
         }
       ],
       "validity": null,

--- a/examples/list_concat.concat_list.tir
+++ b/examples/list_concat.concat_list.tir
@@ -128,7 +128,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 0
+      }
     }
   ],
   "validity": null,

--- a/examples/local_vars.ast
+++ b/examples/local_vars.ast
@@ -195,7 +195,8 @@
             "dummy": false,
             "start": 302,
             "end": 366
-          }
+          },
+          "declared_index": 0
         }
       ],
       "validity": null,

--- a/examples/local_vars.mint_from_local.tir
+++ b/examples/local_vars.mint_from_local.tir
@@ -77,7 +77,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 0
+      }
     }
   ],
   "validity": null,

--- a/examples/map.ast
+++ b/examples/map.ast
@@ -141,7 +141,8 @@
             "dummy": false,
             "start": 190,
             "end": 257
-          }
+          },
+          "declared_index": 0
         },
         {
           "name": null,
@@ -336,7 +337,8 @@
             "dummy": false,
             "start": 263,
             "end": 418
-          }
+          },
+          "declared_index": 1
         }
       ],
       "validity": null,

--- a/examples/map.transfer.tir
+++ b/examples/map.transfer.tir
@@ -72,7 +72,10 @@
           }
         ]
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 0
+      }
     },
     {
       "address": {
@@ -191,7 +194,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 1
+      }
     }
   ],
   "validity": null,

--- a/examples/min_utxo.transfer_min.tir
+++ b/examples/min_utxo.transfer_min.tir
@@ -76,7 +76,10 @@
           }
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 0
+      }
     },
     {
       "address": {
@@ -163,7 +166,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 1
+      }
     }
   ],
   "validity": null,

--- a/examples/reference_script.ast
+++ b/examples/reference_script.ast
@@ -179,7 +179,8 @@
             "dummy": false,
             "start": 323,
             "end": 404
-          }
+          },
+          "declared_index": 1
         }
       ],
       "validity": null,
@@ -257,7 +258,8 @@
                 "dummy": false,
                 "start": 173,
                 "end": 317
-              }
+              },
+              "declared_index": 0
             }
           }
         }
@@ -448,7 +450,8 @@
             "dummy": false,
             "start": 675,
             "end": 756
-          }
+          },
+          "declared_index": 1
         }
       ],
       "validity": null,
@@ -526,7 +529,8 @@
                 "dummy": false,
                 "start": 549,
                 "end": 669
-              }
+              },
+              "declared_index": 0
             }
           }
         }

--- a/examples/reference_script.publish_native.tir
+++ b/examples/reference_script.publish_native.tir
@@ -127,7 +127,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 1
+      }
     }
   ],
   "validity": null,
@@ -137,6 +140,17 @@
     {
       "name": "cardano_publish",
       "data": {
+        "version": {
+          "Number": 0
+        },
+        "to": {
+          "EvalParam": {
+            "ExpectValue": [
+              "receiver",
+              "Address"
+            ]
+          }
+        },
         "script": {
           "Bytes": [
             130,
@@ -163,15 +177,7 @@
             }
           ]
         },
-        "to": {
-          "EvalParam": {
-            "ExpectValue": [
-              "receiver",
-              "Address"
-            ]
-          }
-        },
-        "version": {
+        "declared_index": {
           "Number": 0
         }
       }

--- a/examples/reference_script.publish_native.tir
+++ b/examples/reference_script.publish_native.tir
@@ -140,27 +140,6 @@
     {
       "name": "cardano_publish",
       "data": {
-        "version": {
-          "Number": 0
-        },
-        "to": {
-          "EvalParam": {
-            "ExpectValue": [
-              "receiver",
-              "Address"
-            ]
-          }
-        },
-        "script": {
-          "Bytes": [
-            130,
-            1,
-            129,
-            130,
-            4,
-            0
-          ]
-        },
         "amount": {
           "Assets": [
             {
@@ -175,6 +154,27 @@
                 }
               }
             }
+          ]
+        },
+        "to": {
+          "EvalParam": {
+            "ExpectValue": [
+              "receiver",
+              "Address"
+            ]
+          }
+        },
+        "version": {
+          "Number": 0
+        },
+        "script": {
+          "Bytes": [
+            130,
+            1,
+            129,
+            130,
+            4,
+            0
           ]
         },
         "declared_index": {

--- a/examples/reference_script.publish_plutus.tir
+++ b/examples/reference_script.publish_plutus.tir
@@ -140,32 +140,8 @@
     {
       "name": "cardano_publish",
       "data": {
-        "amount": {
-          "Assets": [
-            {
-              "policy": "None",
-              "asset_name": "None",
-              "amount": {
-                "EvalParam": {
-                  "ExpectValue": [
-                    "quantity",
-                    "Int"
-                  ]
-                }
-              }
-            }
-          ]
-        },
-        "version": {
-          "Number": 3
-        },
-        "to": {
-          "EvalParam": {
-            "ExpectValue": [
-              "receiver",
-              "Address"
-            ]
-          }
+        "declared_index": {
+          "Number": 0
         },
         "script": {
           "Bytes": [
@@ -189,8 +165,32 @@
             105
           ]
         },
-        "declared_index": {
-          "Number": 0
+        "to": {
+          "EvalParam": {
+            "ExpectValue": [
+              "receiver",
+              "Address"
+            ]
+          }
+        },
+        "amount": {
+          "Assets": [
+            {
+              "policy": "None",
+              "asset_name": "None",
+              "amount": {
+                "EvalParam": {
+                  "ExpectValue": [
+                    "quantity",
+                    "Int"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "version": {
+          "Number": 3
         }
       }
     }

--- a/examples/reference_script.publish_plutus.tir
+++ b/examples/reference_script.publish_plutus.tir
@@ -127,7 +127,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 1
+      }
     }
   ],
   "validity": null,
@@ -137,9 +140,6 @@
     {
       "name": "cardano_publish",
       "data": {
-        "version": {
-          "Number": 3
-        },
         "amount": {
           "Assets": [
             {
@@ -155,6 +155,17 @@
               }
             }
           ]
+        },
+        "version": {
+          "Number": 3
+        },
+        "to": {
+          "EvalParam": {
+            "ExpectValue": [
+              "receiver",
+              "Address"
+            ]
+          }
         },
         "script": {
           "Bytes": [
@@ -178,13 +189,8 @@
             105
           ]
         },
-        "to": {
-          "EvalParam": {
-            "ExpectValue": [
-              "receiver",
-              "Address"
-            ]
-          }
+        "declared_index": {
+          "Number": 0
         }
       }
     }

--- a/examples/swap.ast
+++ b/examples/swap.ast
@@ -465,7 +465,8 @@
             "dummy": false,
             "start": 479,
             "end": 682
-          }
+          },
+          "declared_index": 0
         },
         {
           "name": null,
@@ -557,7 +558,8 @@
             "dummy": false,
             "start": 688,
             "end": 765
-          }
+          },
+          "declared_index": 1
         }
       ],
       "validity": null,

--- a/examples/swap.swap.tir
+++ b/examples/swap.swap.tir
@@ -249,7 +249,10 @@
           }
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 0
+      }
     },
     {
       "address": {
@@ -339,7 +342,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 1
+      }
     }
   ],
   "validity": null,

--- a/examples/transfer.ast
+++ b/examples/transfer.ast
@@ -141,7 +141,8 @@
             "dummy": false,
             "start": 159,
             "end": 226
-          }
+          },
+          "declared_index": 0
         },
         {
           "name": null,
@@ -233,7 +234,8 @@
             "dummy": false,
             "start": 232,
             "end": 313
-          }
+          },
+          "declared_index": 1
         }
       ],
       "validity": null,

--- a/examples/transfer.transfer.tir
+++ b/examples/transfer.transfer.tir
@@ -72,7 +72,10 @@
           }
         ]
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 0
+      }
     },
     {
       "address": {
@@ -155,7 +158,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 1
+      }
     }
   ],
   "validity": null,

--- a/examples/vesting.ast
+++ b/examples/vesting.ast
@@ -271,7 +271,8 @@
             "dummy": false,
             "start": 323,
             "end": 526
-          }
+          },
+          "declared_index": 0
         },
         {
           "name": null,
@@ -363,7 +364,8 @@
             "dummy": false,
             "start": 532,
             "end": 612
-          }
+          },
+          "declared_index": 1
         }
       ],
       "validity": null,
@@ -564,7 +566,8 @@
             "dummy": false,
             "start": 911,
             "end": 994
-          }
+          },
+          "declared_index": 0
         }
       ],
       "validity": null,

--- a/examples/vesting.lock.tir
+++ b/examples/vesting.lock.tir
@@ -130,7 +130,10 @@
           }
         ]
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 0
+      }
     },
     {
       "address": {
@@ -213,7 +216,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 1
+      }
     }
   ],
   "validity": null,

--- a/examples/vesting.unlock.tir
+++ b/examples/vesting.unlock.tir
@@ -210,7 +210,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 0
+      }
     }
   ],
   "validity": null,

--- a/examples/withdrawal.ast
+++ b/examples/withdrawal.ast
@@ -141,7 +141,8 @@
             "dummy": false,
             "start": 158,
             "end": 225
-          }
+          },
+          "declared_index": 0
         },
         {
           "name": null,
@@ -233,7 +234,8 @@
             "dummy": false,
             "start": 231,
             "end": 312
-          }
+          },
+          "declared_index": 1
         }
       ],
       "validity": null,

--- a/examples/withdrawal.transfer.tir
+++ b/examples/withdrawal.transfer.tir
@@ -72,7 +72,10 @@
           }
         ]
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 0
+      }
     },
     {
       "address": {
@@ -155,7 +158,10 @@
           ]
         }
       },
-      "optional": false
+      "optional": false,
+      "declared_index": {
+        "Number": 1
+      }
     }
   ],
   "validity": null,


### PR DESCRIPTION
This PR relies and fixes the joint behavior of the following two PRs:
- Publish block allows having min_utxo: https://github.com/tx3-lang/tx3/pull/295
- Keeping order of utxos makes it so that min utxo tracked index is not the declared index: https://github.com/tx3-lang/tx3/pull/285

