### PR TITLE
Filter pool_set based on defined constraints

### DIFF
--- a/crates/tx3-resolver/src/inputs/select/mod.rs
+++ b/crates/tx3-resolver/src/inputs/select/mod.rs
@@ -81,11 +81,24 @@ impl PendingQuery {
     }
 
     fn build_candidates(&mut self, pool: &HashMap<UtxoRef, Utxo>) {
-        let target = self.query.min_amount.clone().unwrap_or(CanonicalAssets::empty());
+        let target = self
+            .query
+            .min_amount
+            .clone()
+            .unwrap_or(CanonicalAssets::empty());
 
         let pool_set: UtxoSet = pool
             .values()
-            .filter(|utxo| !self.query.collateral || utxo.assets.is_only_naked())
+            .filter(|utxo| {
+                let collateral_ok = !self.query.collateral || utxo.assets.is_only_naked();
+                let address_ok = self
+                    .query
+                    .address
+                    .as_ref()
+                    .map_or(true, |a| utxo.address == *a);
+                let refs_ok = self.query.refs.is_empty() || self.query.refs.contains(&utxo.r#ref);
+                collateral_ok && address_ok && refs_ok
+            })
             .cloned()
             .collect();
 


### PR DESCRIPTION
This pull request enhances the candidate selection logic in the `PendingQuery` implementation, making it more flexible and precise by adding new filtering conditions based on address and references.

Improvements to candidate selection logic:

* Updated the `build_candidates` method in `select/mod.rs` to filter UTXOs not only by collateral status, but also by matching address (if specified) and by checking if their references are included in the query's `refs` set (if specified). This ensures that only UTXOs meeting all relevant criteria are considered as candidates.