### PR TITLE
feat: support empty maps

### DIFF
--- a/crates/tx3-lang/src/ast.rs
+++ b/crates/tx3-lang/src/ast.rs
@@ -637,7 +637,11 @@ impl MapConstructor {
             let value_type = first_field.value.target_type()?;
             Some(Type::Map(Box::new(key_type), Box::new(value_type)))
         } else {
-            None
+            // Empty map literal: element types are unknown from the literal
+            // alone. Return a Map with Undefined inner types so the analyzer
+            // can still treat this as a Map; type coherence is checked by the
+            // enclosing context (e.g. a struct field of declared Map<K,V> type).
+            Some(Type::Map(Box::new(Type::Undefined), Box::new(Type::Undefined)))
         }
     }
 }

--- a/crates/tx3-lang/src/tx3.pest
+++ b/crates/tx3-lang/src/tx3.pest
@@ -199,7 +199,7 @@ map_field = {
 }
 
 map_constructor = {
-    "{" ~  (map_field ~ ",")+ ~ "}"
+    "{" ~  (map_field ~ ",")* ~ "}"
 }
 
 // input block


### PR DESCRIPTION
Allow empty maps like in this case:
```
output position_output {
    to: StakingScript,
    amount: min_utxo(position_output) + tokens + staking_position_nft,
    datum: StakingDatum::StakingPosition {
        sp_content: StakingPositionContent {
            st_owner: owner_pkh,
            st_locked_amount: {}, // Empty map
            st_position_snapshot: current_snapshot,
        },
    },
}
```