### PR TITLE
docs(specs): add normative v1beta0 language specification

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,49 @@
+# Tx3 Language Specification
+
+This directory is the canonical home of the **normative specification** of the
+Tx3 source language.
+
+## Scope
+
+The specification covers the **high-level Tx3 source language**: the surface
+syntax authored in `.tx3` files, its type system, and the static semantics that
+a conforming compiler applies before lowering. It does **not** cover:
+
+- The Tx3 Intermediate Representation (TIR). TIR is specified separately under
+  [`tx3-lang/tir`](https://github.com/tx3-lang/tir).
+- The Transaction Resolver Protocol (TRP). See
+  [`tx3-lang/trp`](https://github.com/tx3-lang/trp).
+- The Transaction Invocation Interface (TII). See
+  [`tx3-lang/tii`](https://github.com/tx3-lang/tii).
+- Codegen frontends, the `trix` toolchain, devnet, or any client SDK.
+
+## Source of truth
+
+The specification under this directory is the **normative** definition of the
+language. Where it disagrees with the reference Rust implementation in
+[`crates/tx3-lang/`](../crates/tx3-lang/), the implementation is the one in
+error. The implementation will be brought into alignment over time.
+
+Until that alignment is complete, the documents under each version directory
+also note any known divergences (see each `09-conformance.md`).
+
+## Versions
+
+| Version    | Status  | Directory              |
+| ---------- | ------- | ---------------------- |
+| `v1beta0`  | current | [`v1beta0/`](v1beta0/) |
+
+A new version directory is created when a breaking change to the language is
+introduced. Within a version, changes are additive and backward compatible. See
+each version's `01-introduction.md` for its versioning policy.
+
+## Audience
+
+- Implementers of Tx3 compilers, analyzers, formatters, language servers, and
+  alternative toolchains.
+- Reviewers proposing changes to the language.
+- Authors writing portable Tx3 programs who need a precise reference for what
+  a conforming compiler MUST accept.
+
+For tutorial-style material aimed at end-user authors of `.tx3` programs, see
+the docs under [`tx3-lang/docs`](https://github.com/tx3-lang/docs).

--- a/specs/v1beta0/01-introduction.md
+++ b/specs/v1beta0/01-introduction.md
@@ -1,0 +1,125 @@
+# 1. Introduction
+
+## 1.1 Scope, goals, non-goals
+
+Tx3 is a domain-specific language for describing **transaction templates** on
+UTxO-based blockchains. A Tx3 program declares the shape of one or more
+transactions together with the parties, assets, policies, types, and
+environment values they refer to. It is not a general-purpose programming
+language and contains no constructs for unbounded loops, recursion, or
+side-effects.
+
+This specification defines, normatively:
+
+- the lexical structure of Tx3 source files (§3);
+- the context-free grammar of Tx3 (§4);
+- the type system (§5);
+- the static semantics applied by a conforming compiler (§6);
+- the meaning of each `tx`-body block (§7);
+- the chain-specific extension namespace currently defined (§8);
+- the conformance criteria for source programs and compilers (§9).
+
+The following are explicitly **out of scope**:
+
+- The Tx3 Intermediate Representation (TIR). Lowering from the source
+  language to TIR is informative throughout this document, but the TIR wire
+  format and its semantics are specified separately by the TIR specification.
+- The Transaction Resolver Protocol (TRP) and the Transaction Invocation
+  Interface (TII).
+- Formal mathematical semantics. Semantics in this document are given in
+  prose. Where precision matters, the prose is supplemented with examples and
+  with grammar fragments.
+- Runtime behavior of a transaction once submitted to a chain. Tx3 describes
+  what a transaction looks like, not what executing it does.
+- Codegen target languages (TypeScript, Rust, Go, Python, …) emitted by the
+  `trix` toolchain.
+
+## 1.2 Conformance terminology
+
+The key words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY**
+in this document are to be interpreted as described in
+[RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and
+[RFC 8174](https://www.rfc-editor.org/rfc/rfc8174), with the additional
+clarification that these key words apply to:
+
+- **Source programs.** A program MUST conform to the grammar of §4 and the
+  rules of §5–§8 to be considered a *conforming Tx3 program*.
+- **Compilers.** A *conforming Tx3 compiler* MUST accept every conforming
+  program and reject every non-conforming one, as further qualified in §9.
+
+Outside of these key words, requirements are stated informatively to aid
+understanding and are not themselves normative.
+
+## 1.3 Document conventions and notation
+
+### Defined terms
+
+A term defined by this specification appears in *italics* on first use within
+a section. Defined terms are stable across the document and are case-sensitive
+where they collide with grammar productions or keywords.
+
+### Grammar notation
+
+The syntactic grammar in §4 is given in a conventional EBNF dialect:
+
+| Symbol            | Meaning                                                      |
+| ----------------- | ------------------------------------------------------------ |
+| `A ::= B`         | production: `A` is defined as `B`.                           |
+| `B C`             | sequence: `B` followed by `C`.                               |
+| `B \| C`          | choice: `B` or `C`.                                          |
+| `B?`              | optional: zero or one `B`.                                   |
+| `B*`              | repetition: zero or more `B`.                                |
+| `B+`              | repetition: one or more `B`.                                 |
+| `( B C )`         | grouping.                                                    |
+| `"foo"`           | the literal character sequence `foo`.                        |
+| `[a-z]`           | a character class.                                           |
+| `// comment`      | a grammar-level comment, not part of the language.           |
+
+Terminal symbols are written between double quotes. Nonterminal symbols are
+written in `lower_snake_case`.
+
+### Code samples
+
+Inline Tx3 code is rendered in a fixed-width font. Multi-line samples appear
+in fenced code blocks tagged `tx3`:
+
+```tx3
+party Alice;
+
+tx greet() {
+    output {
+        to: Alice,
+        amount: Ada(1),
+    }
+}
+```
+
+Samples are illustrative and not normative unless explicitly marked otherwise.
+
+### Cross-references
+
+Cross-references to other sections take the form `§<n>` (e.g. `§4.2`).
+References to specific grammar productions name the production directly
+(e.g. `<tx_def>`). References to RFCs and other external standards are given
+as hyperlinks at first use.
+
+## 1.4 Versioning policy
+
+The specification is versioned independently of the reference implementation.
+Each version lives in its own directory under `specs/` (this document is the
+`v1beta0` version).
+
+- Within a version, changes are **additive and backward compatible**. A
+  program that conforms to `v1betaN` MUST continue to conform to any
+  subsequent patch revision of `v1betaN`.
+- A change that would cause a previously conforming program to no longer
+  conform, or that would change the meaning of an existing program, is a
+  **breaking change**. Breaking changes are made by creating a new version
+  directory.
+- The current version, `v1beta0`, is in **beta**: while breaking changes are
+  not expected to be frequent, they are permitted as the language stabilises
+  toward `v1`.
+
+Implementations SHOULD advertise the highest specification version they
+conform to and SHOULD document any extensions or known divergences from that
+version.

--- a/specs/v1beta0/02-domain-model.md
+++ b/specs/v1beta0/02-domain-model.md
@@ -1,0 +1,108 @@
+# 2. Domain model
+
+This section describes, informally, the abstract entities that a Tx3 program
+manipulates. It is non-normative; precise definitions follow in §3–§8. It is
+intended to give the reader a mental model before encountering the grammar.
+
+## 2.1 Programs
+
+A Tx3 *program* is a sequence of top-level definitions held in one or more
+source files. The top-level definitions, in their declared kinds, are:
+
+- *environment* (`env`): typed external inputs supplied at compile or
+  resolution time.
+- *asset definitions* (`asset`): named native asset classes.
+- *party definitions* (`party`): named participants in a transaction.
+- *policy definitions* (`policy`): named minting/spending policies, either
+  declared by hash literal or constructed from constituent fields.
+- *type definitions* (`type`): records, sum types (variants), and aliases.
+- *transaction templates* (`tx`): parameterised templates for transactions.
+
+A program declares at most one `env` block. All other top-level kinds may
+appear zero or more times. The order of top-level definitions is not
+significant for resolution (see §6.1).
+
+## 2.2 Transaction templates
+
+A *transaction template* is the central artefact of Tx3. A template
+declares:
+
+- a name and a list of typed *parameters*;
+- a body composed of *blocks* (input, output, mint, burn, reference,
+  collateral, validity, signers, metadata, locals, plus chain-specific
+  extension blocks).
+
+A template is **not** a transaction. It is a recipe for producing one. Given a
+template, a set of argument values for its parameters, an environment, and a
+chain snapshot, a resolver (see TRP) produces a concrete transaction in the
+TIR wire format, which is then encoded to the target chain's native format.
+
+The act of *declaring* a template is what this specification governs. The act
+of *resolving* a template into a transaction is governed by TRP and is out of
+scope.
+
+## 2.3 Data expressions
+
+Most positions inside a transaction template that hold a value are filled by
+a *data expression*. Data expressions cover:
+
+- literal values (integers, booleans, byte strings, strings, UTxO references,
+  the unit value);
+- compound constructors (records, variants, lists, maps, asset values);
+- identifier references to parameters, locals, parties, policies, assets,
+  inputs, references, outputs, type-defined symbols, and a small set of
+  built-ins;
+- a restricted set of operators: addition (`+`), subtraction (`-`), prefix
+  negation (`!`), property access (`.`), and indexing (`[…]`);
+- a small set of built-in functions: `min_utxo`, `tip_slot`, `slot_to_time`,
+  `time_to_slot`, plus `concat` and the `AnyAsset` constructor.
+
+The expression language is intentionally restricted. It has no control flow,
+no user-defined functions, no comparison operators, and no boolean
+combinators. Everything that requires computation beyond simple arithmetic
+and aggregation is the job of the resolver, not the source language.
+
+## 2.4 Inputs, outputs, references, and named values
+
+A transaction template names some of its component values so they can be
+referred to from elsewhere in the same template:
+
+- *Input blocks* carry a required identifier. The identifier denotes the UTxO
+  that the input resolves to. Property access (e.g. `source.policy`) and
+  arithmetic on input identifiers (e.g. `source - fees`) are common.
+- *Output blocks* may carry an optional identifier. A named output can be
+  referenced by other blocks within the same template (e.g. as the argument
+  to `min_utxo`).
+- *Reference blocks* carry a required identifier and denote a read-only UTxO
+  reference.
+- *Locals blocks* introduce named expressions that abbreviate sub-expressions
+  used elsewhere in the template.
+
+Within the body of a `tx`, these names live in a single shared scope (see
+§6.1). Names need not be declared before use; in particular, output names may
+be referenced from other blocks regardless of textual order.
+
+## 2.5 The compilation pipeline (informative)
+
+A conforming compiler processes a Tx3 program in the following phases. The
+spec is normative only over the first two; lowering is described informatively
+to set the boundary with TIR.
+
+1. **Lexing and parsing.** The source text is tokenised and parsed into an
+   abstract syntax tree per §3 and §4.
+2. **Analysis.** The AST is checked for the validation rules in §5 and §6.
+   Symbol references are resolved against the surrounding scope.
+3. **Lowering.** The analyzed AST is lowered to TIR. Lowering is described by
+   the TIR specification, not by this document.
+
+Errors detected in phase 1 are *syntax errors*. Errors detected in phase 2
+are *semantic errors*. A conforming compiler MUST emit at least one diagnostic
+for any program that violates a rule from §3–§8 (see §9).
+
+## 2.6 Chain genericity
+
+The core of the language (§3–§7) is intended to be chain-agnostic. Constructs
+that are specific to a particular target chain live under a dedicated
+namespace. The only fully defined namespace in `v1beta0` is `cardano::` (§8).
+The token `bitcoin` is reserved for a future Bitcoin namespace and is not
+otherwise specified by this version.

--- a/specs/v1beta0/03-lexical-structure.md
+++ b/specs/v1beta0/03-lexical-structure.md
@@ -1,0 +1,214 @@
+# 3. Lexical structure
+
+This section defines how a Tx3 source file is decomposed into tokens.
+
+## 3.1 Source representation
+
+A Tx3 source file is a sequence of Unicode characters encoded as UTF-8.
+Conforming compilers MUST accept UTF-8 input. Behaviour on input that is not
+well-formed UTF-8 is undefined.
+
+The identifier and literal grammars of `v1beta0` are restricted to ASCII (see
+§3.4, §3.5). Non-ASCII Unicode characters outside string literals and
+comments are syntax errors. Within string literals and comments, non-ASCII
+bytes are permitted but uninterpreted (see §3.5.2).
+
+A *line terminator* is either the single character U+000A (LF) or the
+character pair U+000D U+000A (CRLF). A lone U+000D (CR) without a following
+U+000A is also accepted and treated as a line terminator. Line terminators
+end line comments and otherwise behave as whitespace.
+
+## 3.2 Whitespace
+
+The following characters are *whitespace*:
+
+- U+0020 (SPACE)
+- U+0009 (HORIZONTAL TAB)
+- U+000A (LINE FEED)
+- U+000D (CARRIAGE RETURN)
+
+Whitespace separates tokens and is otherwise insignificant. It MUST appear
+between adjacent tokens that would otherwise be lexically merged (e.g.
+between two identifiers, or between a keyword and an identifier).
+
+## 3.3 Comments
+
+Tx3 has two kinds of comments. Both are equivalent to whitespace for the
+purposes of tokenisation.
+
+- **Line comments** begin with `//` and extend to the next line terminator
+  (exclusive).
+- **Block comments** begin with `/*` and extend to the next `*/`. Block
+  comments **do not nest**: the first `*/` after the opening `/*` ends the
+  comment.
+
+A `/*` that is never closed is a syntax error.
+
+## 3.4 Identifiers
+
+An *identifier* matches the regular expression:
+
+```
+[A-Za-z] [A-Za-z0-9_]*
+```
+
+That is: identifiers start with an ASCII letter and continue with any number
+of ASCII letters, ASCII digits, or underscores. Identifiers MUST NOT begin
+with an underscore or a digit.
+
+Identifiers are **case-sensitive**: `foo`, `Foo`, and `FOO` are distinct.
+
+Identifiers that match a keyword (§3.6) are not identifiers; they are
+keywords. There is no escaping mechanism to use a keyword as an identifier.
+
+By convention (not enforced by this specification):
+
+- Type names and constructor names use `UpperCamelCase`.
+- Value names, parameter names, and block-local names use `snake_case`.
+
+## 3.5 Literals
+
+### 3.5.1 Integer literals
+
+An *integer literal* matches:
+
+```
+"-"? [0-9]+
+```
+
+An optional ASCII minus sign followed by one or more ASCII decimal digits.
+
+Integer literals are interpreted as values of type `Int` (§5.1). A conforming
+compiler MUST support, at minimum, the signed 64-bit two's-complement range
+(`-2^63` through `2^63 - 1`). Behaviour for literals outside this range is
+implementation-defined; conforming compilers SHOULD either reject the literal
+or extend the supported range.
+
+### 3.5.2 String literals
+
+A *string literal* is a sequence of bytes enclosed in double quotes:
+
+```
+"\"" (any byte except "\"")* "\""
+```
+
+There is **no escape syntax** in `v1beta0`. A string literal cannot contain
+the double-quote character. The literal denotes the UTF-8 bytes between the
+quotes; a string literal has type `Bytes` (§5.1).
+
+Implementations SHOULD warn on string literals that contain bytes outside the
+printable ASCII range, but MUST NOT reject them.
+
+### 3.5.3 Hex-string literals
+
+A *hex-string literal* matches:
+
+```
+"0x" [0-9a-fA-F]+
+```
+
+A hex-string literal denotes a sequence of bytes obtained by interpreting
+each pair of hexadecimal digits as one byte. The number of hexadecimal digits
+SHOULD be even; behaviour for an odd-length hex-string literal is
+implementation-defined.
+
+A hex-string literal has type `Bytes` (§5.1).
+
+### 3.5.4 Boolean literals
+
+A *boolean literal* is one of the keywords `true` or `false`, denoting the
+two values of type `Bool` (§5.1).
+
+### 3.5.5 The unit literal
+
+The literal `()` denotes the single value of the `Unit` type (§5.1). A unit
+literal is most commonly used as a placeholder for redeemers and other slots
+where no payload is required.
+
+### 3.5.6 UTxO-reference literals
+
+A *UTxO-reference literal* matches:
+
+```
+"0x" [0-9a-fA-F]+ "#" [0-9]+
+```
+
+That is: a hex-string syntactically identical to a hex-string literal,
+immediately followed by `#` and a decimal integer. The hex part denotes a
+transaction hash; the decimal part denotes a non-negative output index.
+
+A UTxO-reference literal has type `UtxoRef` (§5.1). Implementations SHOULD
+warn if the hex part does not contain an even number of digits, or if its
+byte length is not 32 (the typical size of a transaction hash on UTxO
+chains).
+
+The UTxO-reference syntax takes precedence over the hex-string syntax when
+both could match: `0xabcd#0` is a UTxO reference, not a hex string followed
+by other tokens.
+
+## 3.6 Keywords
+
+The following identifiers are *reserved keywords* and MUST NOT be used as
+user-defined identifiers:
+
+```
+env       asset     party     policy    type      tx
+input     output    mint      burn      reference collateral
+validity  signers   metadata  locals    cardano   bitcoin
+true      false
+Int       Bool      Bytes     AnyAsset  Address   UtxoRef
+List      Map
+```
+
+Within blocks, the following *contextual field names* are syntactically
+distinguished and act as keywords inside their respective blocks:
+
+```
+from        datum_is    min_amount  redeemer    ref
+to          amount      datum
+until_slot  since_slot
+hash        script
+drep        stake       pool
+version     coin
+```
+
+Contextual field names are not reserved at the program level; a top-level
+identifier may share the name. Inside a block where the name has a
+designated role, the name is consumed as that role.
+
+## 3.7 Operators and punctuation
+
+The following tokens are operators or punctuation:
+
+```
++   -   !
+.   [   ]
+(   )   {   }
+,   ;   :   =
+<   >
+::   ...   #
+?   *
+```
+
+Operator precedence and associativity are given in §4.5.
+
+The token `*` is used both as a flag on `input` blocks (`input*`) and is
+otherwise reserved; it is **not** a multiplication operator.
+
+The token `?` is used as a flag on `output` blocks (`output?`); it is
+otherwise reserved.
+
+The token `#` is used only inside UTxO-reference literals (§3.5.6).
+
+The token `...` is used only inside variant-case constructors as a spread
+operator (§4.4).
+
+The token `::` is used both inside chain-specific block prefixes
+(`cardano::…`) and inside explicit variant-case constructors (§4.4).
+
+## 3.8 Token disambiguation
+
+Lexing is greedy: at each position, the longest token that matches the input
+is consumed. As a special case, a hex-string literal that is immediately
+followed by `#` and decimal digits is consumed as a single UTxO-reference
+literal (§3.5.6).

--- a/specs/v1beta0/04-syntactic-grammar.md
+++ b/specs/v1beta0/04-syntactic-grammar.md
@@ -1,0 +1,377 @@
+# 4. Syntactic grammar
+
+This section gives the complete context-free grammar of Tx3 in EBNF. The
+grammar covers syntax only; semantic restrictions (e.g. "metadata keys
+MUST be integers") live in §6 and §7.
+
+The notation is as defined in §1.3. Whitespace and comments (§3.2, §3.3) are
+implicitly permitted between any two adjacent grammar symbols and are not
+written into the productions.
+
+## 4.1 Program
+
+```
+program ::= top_level_def*
+
+top_level_def ::=
+      env_def
+    | asset_def
+    | party_def
+    | policy_def
+    | type_def
+    | tx_def
+```
+
+Top-level definitions MAY appear in any order. At most one `env_def` SHOULD
+appear in a program (§6.2). All other kinds MAY appear any number of times,
+subject to the no-duplicate-definitions rule of §6.2.
+
+## 4.2 Top-level definitions
+
+### 4.2.1 Environment
+
+```
+env_def     ::= "env" "{" (env_field ",")+ "}"
+env_field   ::= identifier ":" type
+```
+
+The `env` block declares typed external inputs that are in scope throughout
+the program (see §6.1). At least one `env_field` MUST appear.
+
+### 4.2.2 Asset
+
+```
+asset_def ::= "asset" identifier "=" data_expr "." data_expr ";"
+```
+
+An *asset definition* introduces a name bound to a (policy, asset-name)
+pair. The first `data_expr` denotes the policy; the second denotes the asset
+name. Both MUST have type `Bytes` after analysis (§6.3).
+
+### 4.2.3 Party
+
+```
+party_def ::= "party" identifier ";"
+```
+
+A *party definition* introduces a participant name. Party definitions carry
+no further structure at the language level; their meaning is supplied at
+resolution time.
+
+### 4.2.4 Policy
+
+```
+policy_def        ::= "policy" identifier policy_def_value
+policy_def_value  ::= policy_def_assign | policy_def_constructor
+
+policy_def_assign ::= "=" hex_string ";"
+
+policy_def_constructor ::= "{" (policy_def_field ",")* "}"
+policy_def_field       ::= policy_def_hash | policy_def_script | policy_def_ref
+policy_def_hash        ::= "hash"   ":" data_expr
+policy_def_script      ::= "script" ":" data_expr
+policy_def_ref         ::= "ref"    ":" data_expr
+```
+
+A *policy definition* either binds the policy to a literal hex-string
+identifier (the assign form) or constructs it from a set of named fields
+(the constructor form). The constructor form MAY include any subset of
+`hash`, `script`, and `ref`. Field-level semantics are specified in §7.10.
+
+### 4.2.5 Type
+
+```
+type_def ::= record_def | variant_def | alias_def
+
+record_def ::= "type" identifier "{" (record_field ",")* "}"
+record_field ::= identifier ":" type
+
+variant_def        ::= "type" identifier "{" (variant_case ",")* "}"
+variant_case       ::= variant_case_struct | variant_case_tuple | variant_case_unit
+variant_case_struct ::= identifier "{" (record_field ",")* "}"
+variant_case_tuple  ::= identifier "(" (type ",")* ")"
+variant_case_unit   ::= identifier
+
+alias_def ::= "type" identifier "=" type ";"
+```
+
+Notes:
+
+- `record_def` and `variant_def` are syntactically disambiguated by the form
+  of the items between `{` and `}`: bare `identifier : type` items form a
+  record; items that start with a capitalised identifier followed by `{`,
+  `(`, or `,`/`}` form a variant. Refer to §5.3 for the semantic
+  distinction.
+- The trailing comma after the last `record_field`, `variant_case`, or
+  variant-case field is required by the grammar above and is conformant
+  Tx3 style.
+
+### 4.2.6 Transaction
+
+```
+tx_def         ::= "tx" identifier parameter_list "{" tx_body_block* "}"
+parameter_list ::= "(" (parameter ("," parameter)* ","?)? ")"
+parameter      ::= identifier ":" type
+```
+
+A *transaction definition* declares a parameterised template. The
+`parameter_list` MAY be empty. Trailing commas are permitted.
+
+## 4.3 Types
+
+```
+type ::= primitive_type | list_type | map_type | custom_type
+
+primitive_type ::= "Int" | "Bool" | "Bytes" | "AnyAsset" | "Address" | "UtxoRef"
+list_type      ::= "List" "<" type ">"
+map_type       ::= "Map"  "<" type "," type ">"
+custom_type    ::= identifier
+```
+
+A `custom_type` is an identifier that MUST resolve to a `record_def`,
+`variant_def`, or `alias_def` (§6).
+
+## 4.4 Data expressions
+
+```
+data_expr ::= data_prefix* data_primary data_postfix*
+              ( data_infix data_prefix* data_primary data_postfix* )*
+
+data_infix   ::= "+" | "-"
+data_prefix  ::= "!"
+data_postfix ::= "." identifier
+               | "[" data_expr "]"
+
+data_primary ::=
+      unit_literal
+    | utxo_ref_literal
+    | hex_string
+    | integer_literal
+    | bool_literal
+    | string_literal
+    | struct_constructor
+    | list_constructor
+    | map_constructor
+    | concat_constructor
+    | any_asset_constructor
+    | fn_call
+    | identifier
+    | "(" data_expr ")"
+
+struct_constructor   ::= identifier variant_case_constructor
+variant_case_constructor ::= explicit_variant_case_constructor
+                           | implicit_variant_case_constructor
+
+explicit_variant_case_constructor ::=
+    "::" identifier "{" (record_constructor_field ",")* spread_expression? "}"
+
+implicit_variant_case_constructor ::=
+    "{" (record_constructor_field ",")* spread_expression? "}"
+
+record_constructor_field ::= identifier ":" data_expr
+spread_expression        ::= "..." data_expr
+
+list_constructor ::= "[" (data_expr ",")* data_expr? "]"
+
+map_constructor ::= "{" (map_field ",")+ "}"
+map_field        ::= data_expr ":" data_expr
+
+concat_constructor    ::= "concat" "(" data_expr "," data_expr ")"
+any_asset_constructor ::= "AnyAsset" "(" data_expr "," data_expr "," data_expr ")"
+
+fn_call ::= identifier "(" (data_expr ("," data_expr)* ","?)? ")"
+```
+
+### 4.4.1 Disambiguation of `{ … }`
+
+A `{ … }` literal in expression position is parsed as:
+
+1. `map_constructor` if at least one comma-separated entry has the form
+   `data_expr ":" data_expr` and the left-hand side of the first entry is
+   not a bare `identifier` immediately followed by `:` and a `data_expr`
+   that is itself parseable as a value;
+2. otherwise as an `implicit_variant_case_constructor` (only meaningful
+   when the surrounding context is a `struct_constructor`).
+
+In practice, a `map_constructor` MUST contain at least one entry, and an
+`implicit_variant_case_constructor` is only valid as the right-hand side of
+a `struct_constructor` (§4.4.2). Conforming compilers SHOULD disambiguate
+based on whether the enclosing position expects an expression value
+(`map_constructor`) versus a record-of-type-fields (`implicit_variant_case_constructor`).
+
+### 4.4.2 Struct constructors
+
+A `struct_constructor` writes:
+
+- `T { f1: e1, f2: e2, }` — implicit case, only valid when `T` is the name
+  of a single-case record type.
+- `T::Case { f1: e1, ..base, }` — explicit case, valid for any variant
+  type.
+- `T::Case { }` — explicit case with no fields, valid for `variant_case_unit`
+  cases.
+
+The optional `spread_expression` (`...base`) MUST appear last and denotes
+"take all fields from `base`, then override with the explicit fields".
+
+### 4.4.3 List and map constructors
+
+- A `list_constructor` MAY be empty (`[]`). A trailing comma is permitted.
+- A `map_constructor` MUST contain at least one entry. There is no
+  syntactic literal for an empty map in `v1beta0`.
+
+## 4.5 Expression precedence and associativity
+
+Data expressions in §4.4 are parsed with the following precedence, from
+tightest binding (highest precedence) to loosest:
+
+| Level | Operators                  | Associativity |
+| ----- | -------------------------- | ------------- |
+| 1     | `.` `[…]` (postfix)        | left          |
+| 2     | `!` (prefix)               | non-assoc     |
+| 3     | `+` `-` (infix)            | left          |
+
+Parentheses `( data_expr )` may be used to override precedence.
+
+There are no further operators in `v1beta0`. In particular, there are no
+comparison operators, no boolean combinators, no multiplicative or
+shift operators, and no ternary form.
+
+## 4.6 Transaction-body blocks
+
+```
+tx_body_block ::=
+      locals_block
+    | reference_block
+    | input_block
+    | collateral_block
+    | burn_block
+    | mint_block
+    | output_block
+    | chain_specific_block
+    | signers_block
+    | metadata_block
+    | validity_block
+```
+
+`tx_body_block`s MAY appear in any order; multiple blocks of the same kind
+MAY appear in a single `tx_def` (subject to the per-block rules in §7).
+
+### 4.6.1 Input
+
+```
+input_block       ::= "input" "*"? identifier "{" (input_block_field ",")* "}"
+input_block_field ::=
+      "from"       ":" data_expr
+    | "datum_is"   ":" type
+    | "min_amount" ":" data_expr
+    | "redeemer"   ":" data_expr
+    | "ref"        ":" data_expr
+```
+
+The optional `"*"` marks the input as *many* (see §7.2). The `identifier`
+is the input's name (§7.2).
+
+### 4.6.2 Reference
+
+```
+reference_block ::= "reference" identifier "{" "ref" ":" data_expr ","
+                    ( "datum_is" ":" type "," )? "}"
+```
+
+A `reference_block` MUST include a `ref` field. The `datum_is` field is
+optional and, if present, MUST be a `type`.
+
+### 4.6.3 Collateral
+
+```
+collateral_block       ::= "collateral" "{" (collateral_block_field ",")* "}"
+collateral_block_field ::=
+      "from"       ":" data_expr
+    | "min_amount" ":" data_expr
+    | "ref"        ":" data_expr
+```
+
+A `collateral_block` has no name. Multiple collateral blocks MAY appear.
+
+### 4.6.4 Output
+
+```
+output_block ::= "output" "?"? identifier? "{" (output_block_field ",")* "}"
+output_block_field ::=
+      "to"     ":" data_expr
+    | "amount" ":" data_expr
+    | "datum"  ":" data_expr
+```
+
+The optional `"?"` flag marks the output as *optional* (§7.3). The
+`identifier`, when present, names the output for later reference.
+
+### 4.6.5 Validity
+
+```
+validity_block       ::= "validity" "{" (validity_block_field ",")* "}"
+validity_block_field ::=
+      "until_slot" ":" data_expr
+    | "since_slot" ":" data_expr
+```
+
+### 4.6.6 Mint and burn
+
+```
+mint_block       ::= "mint" "{" (mint_block_field ",")* "}"
+burn_block       ::= "burn" "{" (mint_block_field ",")* "}"
+mint_block_field ::=
+      "amount"   ":" data_expr
+    | "redeemer" ":" data_expr
+```
+
+`burn_block` shares the field grammar of `mint_block`.
+
+### 4.6.7 Signers
+
+```
+signers_block ::= "signers" "{" (data_expr ",")* "}"
+```
+
+A `signers_block` is a (possibly empty) comma-separated list of data
+expressions, each denoting a required signer (§7.7).
+
+### 4.6.8 Metadata
+
+```
+metadata_block       ::= "metadata" "{" (metadata_block_field ",")+ "}"
+metadata_block_field ::= data_expr ":" data_expr
+```
+
+A `metadata_block` MUST contain at least one entry. Syntactic keys are
+arbitrary `data_expr`; §6.5 restricts them to integer-typed expressions.
+
+### 4.6.9 Locals
+
+```
+locals_block  ::= "locals" "{" (locals_assign ",")+ "}"
+locals_assign ::= identifier ":" data_expr
+```
+
+A `locals_block` MUST contain at least one assignment.
+
+### 4.6.10 Chain-specific
+
+```
+chain_specific_block ::= cardano_block | bitcoin_block
+
+cardano_block ::= "cardano" "::" cardano_inner
+
+bitcoin_block ::= "bitcoin" "::" identifier
+```
+
+The `cardano_inner` productions are given in §8. `bitcoin_block` is
+reserved syntax in `v1beta0`; conforming compilers MUST parse it but SHOULD
+report a diagnostic indicating that the Bitcoin namespace is not defined by
+this version of the specification.
+
+## 4.7 Tokens used elsewhere
+
+The terminal productions `identifier`, `integer_literal`, `bool_literal`,
+`string_literal`, `hex_string`, `unit_literal`, and `utxo_ref_literal` are
+defined lexically in §3.5.

--- a/specs/v1beta0/05-type-system.md
+++ b/specs/v1beta0/05-type-system.md
@@ -1,0 +1,253 @@
+# 5. Type system
+
+Tx3 is statically typed. Every value-bearing expression has a type that is
+known after analysis. The type system is nominal, monomorphic, and has no
+implicit coercions.
+
+This section defines the types of `v1beta0`. The rules that compute types
+for expressions and check them in context are given in §6.
+
+## 5.1 Primitive types
+
+The following types are *primitive* and reserved as keywords (§3.6):
+
+| Type       | Surface keyword | Value space (informal)                                                |
+| ---------- | --------------- | --------------------------------------------------------------------- |
+| `Int`      | `Int`           | Signed integers; conforming compilers MUST support at least 64-bit two's-complement (§3.5.1). |
+| `Bool`     | `Bool`          | The two values `true` and `false`.                                    |
+| `Bytes`    | `Bytes`         | Finite-length byte strings.                                           |
+| `Address` | `Address`       | A chain address; the concrete representation is chain-defined.        |
+| `UtxoRef` | `UtxoRef`       | A reference to a previous transaction output (tx hash + output index). |
+| `AnyAsset`| `AnyAsset`      | A `(policy, asset_name, amount)` triple denoting a quantity of one asset class. |
+
+In addition, the type `Unit` exists as the type of the unit literal `()`
+(§3.5.5). `Unit` is **not** a surface keyword and cannot be written in a
+`type` position; it arises only implicitly from `()` expressions.
+
+## 5.2 Compound types
+
+```
+List<T>      ::  list of values, each of type T
+Map<K, V>    ::  finite mapping from keys of type K to values of type V
+```
+
+Both `List` and `Map` are *parametric type constructors* applied at the
+syntactic level. They do not introduce parametric polymorphism into the
+expression language: each occurrence of `List<T>` or `Map<K, V>` is a
+distinct concrete type.
+
+Constraints:
+
+- `T`, `K`, and `V` MAY be any type, including other compound types and
+  user-defined types.
+- A `List<T>` constructed from a `list_constructor` (§4.4) takes its
+  element type from the type of its first element; an empty
+  `list_constructor` MUST appear in a context that supplies the element
+  type, or its type is `List<Undefined>` (an internal placeholder; see
+  §6.6).
+- A `Map<K, V>` constructed from a `map_constructor` takes `K` and `V`
+  from the first entry; subsequent entries' key and value types MUST match
+  (§6.3).
+
+## 5.3 User-defined types
+
+Three forms of user-defined type are introduced by `type_def` (§4.2.5):
+
+### 5.3.1 Records
+
+A *record* is declared with a single brace-delimited body whose entries are
+all `identifier : type` pairs:
+
+```tx3
+type State {
+    lock_until: Int,
+    owner: Bytes,
+    beneficiary: Bytes,
+}
+```
+
+A record is a nominal product type. Its values are constructed with a
+single-case implicit `struct_constructor` (§4.4.2):
+
+```tx3
+State { lock_until: until, owner: Owner, beneficiary: Beneficiary, }
+```
+
+A record is semantically equivalent to a `variant_def` with exactly one
+`variant_case_struct` whose name matches the type name.
+
+### 5.3.2 Variants
+
+A *variant* is declared with a single brace-delimited body whose entries are
+all `variant_case`s (struct, tuple, or unit form):
+
+```tx3
+type Status {
+    Pending,
+    Active { since: Int, },
+    Cancelled(Bytes,),
+}
+```
+
+A variant value is constructed with an explicit `struct_constructor`
+naming the variant type and the chosen case:
+
+```tx3
+Status::Pending { }
+Status::Active { since: 42, }
+```
+
+Each `variant_case` introduces a constructor whose case name MUST be unique
+within the variant.
+
+Tuple-form cases (`Foo(Int, Bytes,)`) are accepted by the grammar (§4.2.5)
+but `v1beta0` does not define an expression-level construction syntax for
+them. Implementations SHOULD reject construction of a tuple-form case until
+the construction syntax is specified in a future version.
+
+### 5.3.3 Aliases
+
+An *alias* introduces a new name for an existing type:
+
+```tx3
+type Amount = Int;
+type Owner  = Bytes;
+```
+
+An alias is transparent: at every position, `Amount` is interchangeable with
+`Int`. Aliases MAY chain through other aliases; cycles are an error (§6.6).
+
+## 5.4 Built-in compound semantics
+
+Two of the primitive types carry built-in *properties* accessible via the
+`.` operator. These are part of the type, not part of any user-defined
+shape:
+
+| Type      | Property      | Property type | Meaning                                  |
+| --------- | ------------- | ------------- | ---------------------------------------- |
+| `AnyAsset`| `policy`      | `Bytes`       | Asset class policy hash.                 |
+| `AnyAsset`| `asset_name`  | `Bytes`       | Asset class name.                        |
+| `AnyAsset`| `amount`      | `Int`         | Quantity.                                |
+| `UtxoRef` | `tx_hash`     | `Bytes`       | Transaction hash component.              |
+| `UtxoRef` | `output_index`| `Int`         | Output index component.                  |
+
+Additional built-in properties MAY be added in future versions and MUST NOT
+shadow user-defined property names of the same type. Where a user-defined
+custom type and a primitive both expose a property of the same name, the
+property of the actual value's type takes precedence.
+
+`List<T>` supports indexing (`xs[i]`) where `i` is of type `Int` (§5.5.2).
+
+## 5.5 Operators
+
+The data-expression language supports a small fixed set of operators.
+
+### 5.5.1 Arithmetic
+
+The infix operators `+` and `-` are defined for the following operand-type
+pairs, both arities binary, left-associative:
+
+| Left type   | Right type  | Result type | Meaning                          |
+| ----------- | ----------- | ----------- | -------------------------------- |
+| `Int`       | `Int`       | `Int`       | Integer addition / subtraction. |
+| `AnyAsset`  | `AnyAsset`  | `AnyAsset`  | Asset-quantity aggregation.     |
+
+Where the left and right operands have compatible compound types that
+contain `Int` or `AnyAsset` components (such as types representing UTxO
+values), implementations MAY extend `+` and `-` to those types provided the
+extension is consistent across operand pairs. Such extensions are out of
+the scope of this version of the specification.
+
+The prefix operator `!` is defined as **arithmetic negation** when applied
+to an operand of numeric type:
+
+| Operand type | Result type |
+| ------------ | ----------- |
+| `Int`        | `Int`       |
+
+`!` is **not** boolean negation. There is no boolean negation operator in
+`v1beta0`.
+
+### 5.5.2 Property and index
+
+The postfix `.` operator takes a value of a type that defines properties
+(§5.4 or user-defined records / variant struct cases) and yields the value
+of the named property. The property MUST exist on the value's static type
+or the compiler MUST reject the expression (§6.6).
+
+The postfix `[…]` operator takes a value of type `List<T>` and an index
+expression of type `Int`, yielding a value of type `T`. Indexing on
+non-list types is a static error (§6.6).
+
+### 5.5.3 `concat`
+
+The built-in `concat(a, b)` yields a value of the same type as `a`. It is
+defined for:
+
+| Operand type | Result type |
+| ------------ | ----------- |
+| `Bytes`      | `Bytes`     |
+| `List<T>`    | `List<T>`   |
+
+Both operands MUST be of the same type after analysis.
+
+### 5.5.4 `AnyAsset`
+
+The built-in `AnyAsset(policy, asset_name, amount)` yields a value of type
+`AnyAsset`. Its arguments MUST have types `Bytes`, `Bytes`, and `Int`
+respectively.
+
+## 5.6 Built-in functions
+
+The following identifiers, when used in `fn_call` position (§4.4), denote
+built-in functions provided by every conforming compiler:
+
+| Name             | Argument types                  | Result type | Notes |
+| ---------------- | ------------------------------- | ----------- | ----- |
+| `min_utxo`       | `(output-name : Identifier)`    | `AnyAsset`  | Computes the minimum lovelace required to make the named output meet the chain's UTxO minimum. The argument is an identifier that MUST resolve to an `output_block` (§7.5). |
+| `tip_slot`       | `()`                            | `Int`       | The current chain tip slot at resolution time. |
+| `slot_to_time`   | `(slot : Int)`                  | `Int`       | Converts a slot number to a POSIX time. |
+| `time_to_slot`   | `(time : Int)`                  | `Int`       | Converts a POSIX time to a slot number. |
+
+`min_utxo` is special: its single argument is treated as an identifier
+reference rather than a general data expression. `tip_slot` MAY be invoked
+either as `tip_slot()` or as the bare identifier `tip_slot` (the latter
+form is accepted but using the call form is RECOMMENDED).
+
+These names occupy the program-global namespace and SHOULD NOT be shadowed
+by user-defined identifiers.
+
+## 5.7 Built-in symbols
+
+In addition to the built-in functions above, the following bare identifiers
+are implicitly bound inside every `tx` body:
+
+| Identifier | Kind  | Type      | Meaning                                                                 |
+| ---------- | ----- | --------- | ----------------------------------------------------------------------- |
+| `fees`     | value | `AnyAsset` | The transaction fee. Subtract from inputs / change as needed (§7.4). |
+| `Ada`      | asset | (asset)   | The chain's native primary asset, available as an asset constructor (e.g. `Ada(1_000_000)`). Defined by a built-in `asset_def` (§5.8). |
+
+## 5.8 Implicit `Ada` asset
+
+Every program implicitly includes the asset definition equivalent to
+`asset Ada = ... . ...;` where the policy and asset-name are chain-defined.
+Programs SHOULD NOT define a top-level `asset Ada` themselves; doing so
+results in a duplicate-definition error (§6.2).
+
+## 5.9 Type equivalence and assignability
+
+Two types `A` and `B` are *type-equivalent* if they are the same primitive,
+the same `List<T>` (with equivalent `T`), the same `Map<K, V>` (with
+equivalent `K` and `V`), refer to the same user-defined type definition
+(after alias chasing), or denote the same internal `Unit`/`Undefined`
+placeholder.
+
+A value of type `A` is *assignable* to a position expecting type `B`
+exactly when `A` and `B` are type-equivalent. There are no implicit
+coercions in `v1beta0`. In particular:
+
+- `Int` does not implicitly convert to `Bytes` or vice versa.
+- `Bytes` does not implicitly convert to `Address`, `UtxoRef`, or
+  `AnyAsset`, even when its byte representation would be valid for the
+  target type. Conversions, where allowed, are expressed by constructors
+  or fields, not by coercion.

--- a/specs/v1beta0/06-static-semantics.md
+++ b/specs/v1beta0/06-static-semantics.md
@@ -1,0 +1,248 @@
+# 6. Static semantics
+
+This section defines what a conforming compiler MUST check after parsing
+and before lowering. Violations of any rule in this section are *semantic
+errors* and MUST be reported with at least one diagnostic.
+
+The rules are organised by scope (§6.1–§6.2), then by expression kind
+(§6.3–§6.7), then by block-level validation (§6.8).
+
+## 6.1 Scopes
+
+A *scope* is a partial map from identifiers to *symbols*. Scopes are
+arranged in a tree by lexical containment. Name resolution walks from the
+innermost scope outward through parent scopes (§6.2).
+
+The scope tree for a program has the following shape:
+
+```
+program scope
+├── (per tx_def) tx scope
+│   ├── (per struct/property/variant access) inner scope (§6.3)
+```
+
+The *program scope* contains:
+
+- one symbol per `env` field, of kind *env-var*;
+- one symbol per `party_def`, of kind *party*;
+- one symbol per `policy_def`, of kind *policy*;
+- one symbol per `asset_def` (including the implicit `Ada` asset), of
+  kind *asset*;
+- one symbol per `record_def` or `variant_def`, of kind *type*;
+- one symbol per `alias_def`, of kind *alias*;
+- the built-in functions `min_utxo`, `tip_slot`, `slot_to_time`,
+  `time_to_slot` (§5.6).
+
+A *tx scope* (one per `tx_def`) extends the program scope with:
+
+- one symbol per parameter, of kind *param-var*, in the order declared;
+- one symbol per `locals_assign` (across all `locals_block`s of the tx),
+  of kind *local-expr*;
+- one symbol per `input_block`, keyed on the input's identifier, of kind
+  *input*;
+- one symbol per `reference_block`, keyed on the reference's identifier,
+  of kind *reference*;
+- one symbol per **named** `output_block`, keyed on the output's
+  identifier, of kind *output*;
+- the bare identifier `fees`, of kind *fees* and type `AnyAsset` (§5.7).
+
+Within a single tx scope, names introduced by parameters, locals, inputs,
+references, and named outputs **share a flat namespace**. The order of
+declaration does not matter for resolution; for example, an output named
+`change` MAY be referenced from an `input` block that appears textually
+before it.
+
+Inner scopes are created when analysing:
+
+- a `struct_constructor`: an inner scope whose symbols are the variant
+  cases of the constructor's type;
+- a `variant_case_constructor`: an inner scope whose symbols are the
+  record fields of that case;
+- a property access `e.p`: an inner scope whose symbols are the properties
+  of `e`'s static type (§5.4 or user-defined).
+
+## 6.2 Name resolution and duplicates
+
+Name lookup at a use site `n` proceeds from the current scope outward to
+the program scope. The first scope in which `n` is bound determines the
+symbol. If `n` is unbound in every enclosing scope and is not a built-in,
+the compiler MUST report a *not-in-scope* error.
+
+Within a single scope, an identifier MUST be bound by at most one
+definition. Multiple `record_def`/`variant_def`/`alias_def`/`party_def`/
+`policy_def`/`asset_def`/`env`-field/parameter/local/input/reference/named
+output with the same name are *duplicate definitions* and MUST be
+rejected. The error MAY name only the first or last occurrence.
+
+The implicit `Ada` asset definition is added by the compiler; redeclaring
+`Ada` at the top level is a duplicate-definition error (§5.8).
+
+## 6.3 Type checking
+
+Every `data_expr` has a *static type* assigned by the analyzer. The static
+type is computed bottom-up as follows:
+
+- Literals have the type given in §3.5 (e.g. `42 : Int`,
+  `"abc" : Bytes`).
+- `()` has type `Unit`.
+- `utxo_ref_literal` has type `UtxoRef`.
+- An `identifier` `n` has the static type associated with the symbol that
+  `n` resolves to: parameter type for *param-var*; the assigned-expression
+  type for *local-expr*; the special compiler type `Utxo` for *input*
+  (§7.2); the `datum_is` type for *reference* when present (§7.6); the
+  output's value type for *output*; `AnyAsset` for `fees` and for `Ada`;
+  the underlying type for *env-var*; and so on. Identifiers that resolve
+  to *type*, *alias*, *party*, *policy*, *asset*, or *function* symbols
+  are not values themselves and may only appear in positions that name
+  one of those kinds (§6.4).
+- A `struct_constructor` has the type named by its `r#type` identifier.
+- A `list_constructor` has type `List<T>` where `T` is the static type of
+  the first element. An empty `list_constructor` has type
+  `List<Undefined>` (an internal placeholder, see §6.6).
+- A `map_constructor` has type `Map<K, V>` where `K` and `V` are the
+  static types of the first entry's key and value.
+- An `any_asset_constructor` has type `AnyAsset`.
+- A `concat_constructor` has the static type of its first argument.
+- A `fn_call` to a built-in has the type listed in §5.6.
+- An `add_op` or `sub_op` has the static type of its left operand.
+- A `negate_op` has the static type of its operand.
+- A `property_op` `e.p` has the type of the property `p` on `e`'s type
+  (§5.4 / §5.3).
+- An `index_op` `e[i]` has type `T` when `e : List<T>`.
+
+A position that *expects* a type `B` accepts an expression whose static
+type `A` is type-equivalent to `B` per §5.9. A mismatch is an
+*invalid-target-type* error.
+
+The following positions impose type expectations:
+
+| Position                                          | Expected type |
+| ------------------------------------------------- | ------------- |
+| Policy and asset-name of `asset_def`              | `Bytes`       |
+| `metadata` value, when literal                    | byte size ≤ 64 (§6.5) |
+| `cardano::withdrawal` `amount`                    | `Int`         |
+| `cardano::treasury_donation` `coin`               | `Int`         |
+| Argument of `slot_to_time` / `time_to_slot`       | `Int`         |
+| Index of `e[i]`                                   | `Int`         |
+| Spread base in a `variant_case_constructor`       | type of the constructor's case |
+
+Conforming compilers MAY additionally check that the argument types of
+`AnyAsset(p, a, q)` are `(Bytes, Bytes, Int)`, that arithmetic operands
+match the patterns of §5.5.1, and that record/variant constructor field
+expressions match their declared field types. Such additional checks are
+RECOMMENDED.
+
+## 6.4 Identifiers in non-value positions
+
+Several positions in the language name symbols rather than evaluate values:
+
+- The right-hand side of `policy P = …` (a `hex_string`).
+- The first argument to `min_utxo(x)` (an *output* identifier).
+- The `from` field of an `input_block` and the `to` field of an
+  `output_block` (a *party* or *policy* identifier, or an expression of
+  type `Address`; see §7.2, §7.3).
+- The `r#type` identifier of a `struct_constructor` (a *type* or *alias*
+  symbol).
+- The case identifier of an `explicit_variant_case_constructor` (a
+  *variant-case* symbol within the surrounding type's inner scope).
+- The field identifier of a `record_constructor_field` (a *record-field*
+  symbol within the surrounding case's inner scope).
+- The property identifier of a `data_property` (`.p`).
+
+When a position names a symbol of the wrong kind, the compiler MUST
+report an *invalid-symbol* error.
+
+## 6.5 Metadata validation
+
+Inside every `metadata_block`:
+
+- Each entry's *key* expression MUST have static type `Int`. Permissible
+  forms in `v1beta0` are an `integer_literal` or an `identifier` that
+  resolves to a symbol of type `Int`. Any other key form is a
+  *metadata-invalid-key-type* error.
+- Each entry's *value*, when it is a `string_literal` or `hex_string`,
+  MUST have a byte length ≤ 64. The byte length of a string is the
+  number of UTF-8 code units between its quotes; the byte length of a
+  hex string is the number of bytes its hex digits encode (half the
+  digit count, rounded down). Exceeding 64 bytes is a
+  *metadata-size-limit-exceeded* error.
+
+Values that are not literal `string_literal` or `hex_string` (e.g.
+identifiers, constructors, arithmetic) are not size-checked at compile
+time; the size limit MUST still be respected at resolution time but is
+beyond the static analysis's reach.
+
+## 6.6 Other static rules
+
+- An `alias_def` whose right-hand side names an undefined type is a
+  *not-in-scope* error.
+- An alias chain that does not terminate at a `record_def` or
+  `variant_def` (e.g. `type A = B; type B = A;`) is **unresolved**;
+  conforming compilers MUST reject any such cyclic chain. Recursive
+  references between distinct `type_def`s that ultimately resolve are
+  permitted.
+- Indexing (`e[i]`) on a non-list type is an *invalid-target-type* error.
+- Property access on a value whose type has no such property is an
+  *invalid-symbol* or *not-in-scope* error (the analyzer may report
+  either).
+- An empty `list_constructor` `[]` whose element type cannot be inferred
+  from context yields the internal type `List<Undefined>`. A program in
+  which `Undefined` reaches a typed position is non-conforming;
+  implementations SHOULD report a clearer error than "undefined".
+- A `struct_constructor` whose `r#type` resolves to an `alias_def` is
+  accepted; the alias is chased to its underlying `record_def` or
+  `variant_def` (§5.3.3).
+
+## 6.7 Resolution order
+
+The analyzer establishes scopes in two passes:
+
+1. The program scope is populated with all top-level symbols. Type
+   definitions and aliases are then resolved in repeated passes until a
+   fixed point is reached (handling forward references between types).
+2. For each `tx_def`, the tx scope is populated and the analyzer iterates
+   to a fixed point so that mutual references between locals, inputs,
+   outputs, and references can be resolved regardless of textual order.
+
+Conforming compilers MAY implement either order or both, but the
+observable result MUST be the same: any cyclic dependency between values
+not mediated by `datum_is` or by structural recursion is a *not-in-scope*
+error.
+
+## 6.8 Block-level validation
+
+In addition to the rules above, each `tx_body_block` is subject to the
+per-block constraints in §7 and §8. The following two rules are
+established here because they are diagnosed by static analysis:
+
+### 6.8.1 Optional outputs MUST NOT carry a datum
+
+An `output_block` with the `"?"` flag MUST NOT include a `datum` field.
+This is an *invalid-optional-output* error.
+
+### 6.8.2 Reference block fields
+
+A `reference_block` MUST include exactly one `ref` field (enforced by the
+grammar in §4.6.2). The optional `datum_is` field, when present, MUST be
+a type that resolves under §6.6.
+
+## 6.9 Catalogue of static-semantic errors
+
+The error categories below are reserved for the conditions described in
+this section. A conforming compiler SHOULD use a stable error identifier
+for each so that downstream tooling can match on it. The reference
+implementation currently uses the identifiers in the right-hand column.
+
+| Category                          | Reference identifier            |
+| --------------------------------- | ------------------------------- |
+| not in scope                      | `tx3::not_in_scope`             |
+| invalid symbol kind               | `tx3::invalid_symbol`           |
+| invalid target type               | `tx3::invalid_type`             |
+| duplicate definition              | `tx3::duplicate_definition`     |
+| optional output has datum         | `tx3::optional_output_datum`    |
+| metadata value > 64 bytes         | `tx3::metadata_size_limit_exceeded` |
+| metadata key not an integer       | `tx3::metadata_invalid_key_type` |
+
+Additional diagnostics MAY be emitted for guidance, but a conforming
+compiler MUST emit at least one diagnostic from the appropriate category
+above for each violation.

--- a/specs/v1beta0/07-transaction-semantics.md
+++ b/specs/v1beta0/07-transaction-semantics.md
@@ -1,0 +1,325 @@
+# 7. Transaction semantics
+
+This section specifies the meaning of each top-level definition kind and
+each `tx`-body block. Where a block carries a name, the rules for that
+name appear in the block's own subsection.
+
+## 7.1 What a transaction template declares
+
+A `tx_def` declares a *transaction template*: a parameterised description
+of how to assemble one concrete transaction. The template fixes the
+**shape** of the transaction (which inputs are consumed, which outputs
+are produced, etc.), but does not fix the **values** that participate.
+Values arrive at resolution time from:
+
+- the user-supplied arguments bound to the `parameter_list`;
+- the `env` block, supplied at compile or resolution time;
+- the chain state observed by the resolver.
+
+Tx3 does not specify how a resolver computes balances, selects UTxOs, or
+calculates fees. It only specifies what the source program guarantees
+about the resulting transaction's shape.
+
+## 7.2 `input` blocks
+
+An `input_block` declares a UTxO consumed by the transaction.
+
+### Fields
+
+| Field        | Required | Type    | Meaning                                                                 |
+| ------------ | -------- | ------- | ----------------------------------------------------------------------- |
+| `from`       | one of `from`/`ref` MUST be present | *party* / *policy* / `Address` | The credential at which the UTxO is held. |
+| `ref`        | see above | `UtxoRef` | An explicit UTxO reference. Selects exactly that UTxO. |
+| `min_amount` | optional | `AnyAsset` | A lower bound on the value the input must contain. |
+| `redeemer`   | optional | any     | A redeemer to attach when the input is script-locked. |
+| `datum_is`   | optional | type    | The expected datum type carried by the input (§7.6). |
+
+### Name
+
+Every `input_block` carries a mandatory identifier. The identifier names
+the resolved input value within the transaction template and binds a
+symbol of kind *input* in the tx scope.
+
+The identifier MAY be used in other expressions in the same tx body as a
+value of the special type *Utxo* whose accessible properties are:
+
+- the datum, with the type declared by `datum_is` (if any);
+- the asset value, which participates in `+` and `-` against `AnyAsset`
+  and other *Utxo* identifiers.
+
+### The `*` flag
+
+An `input` may be marked with a postfix `*` (between `input` and the
+identifier) to indicate *many*. A many-input matches any number of UTxOs
+(including zero) satisfying the block's predicates. The resolver
+aggregates them; the surface language treats `xs` of `input* xs { … }`
+as a single aggregate value. The detailed behaviour of `*` is specified
+informally in `v1beta0` and refined by the resolver in TRP.
+
+### Field combinations
+
+- `from` and `ref` MAY both be specified; doing so constrains the
+  resolution further but does not change the input's static type.
+- `redeemer` is only meaningful when the input is script-locked;
+  resolvers MAY ignore a redeemer set on a non-script input.
+
+## 7.3 `output` blocks
+
+An `output_block` declares a UTxO produced by the transaction.
+
+### Fields
+
+| Field    | Required | Type     | Meaning                                                                 |
+| -------- | -------- | -------- | ----------------------------------------------------------------------- |
+| `to`     | required | *party* / *policy* / `Address` | The recipient credential. |
+| `amount` | required | `AnyAsset` | The value attached to the output. |
+| `datum`  | optional | any (custom type) | A datum to attach. MUST NOT be set on optional outputs (§6.8.1). |
+
+### Name
+
+An `output_block` MAY carry an identifier (after the optional `?` flag).
+Named outputs bind a symbol of kind *output* in the tx scope, addressable
+by other blocks (most commonly by `min_utxo`).
+
+### The `?` flag
+
+An output marked with `?` is *optional*: if the resolver's value-balancing
+pass would otherwise produce a zero-amount output, the optional output
+MAY be omitted from the resulting transaction. Optional outputs MUST NOT
+carry a `datum` field (§6.8.1).
+
+## 7.4 The `fees` identifier
+
+Inside every `tx` body, the bare identifier `fees` denotes the fee paid
+by the transaction. It has type `AnyAsset` (specifically the chain's
+native fee asset). It is typically subtracted from a change output:
+
+```tx3
+output {
+    to: Sender,
+    amount: source - Ada(quantity) - fees,
+}
+```
+
+`fees` is not a parameter; the resolver computes the concrete fee. The
+source language guarantees only that the symbol `fees` is in scope and
+that the expression's static type matches the surrounding context.
+
+## 7.5 `min_utxo` built-in
+
+`min_utxo(out)` evaluates to the minimum chain-required value (typically
+in Ada) needed to make the output named `out` viable. Its single argument
+MUST be an identifier that resolves to an *output* symbol within the same
+tx scope. Use it as the `amount` field of the named output itself, or
+inside a downstream value computation.
+
+```tx3
+output target {
+    to: Recipient,
+    amount: min_utxo(target),
+}
+```
+
+## 7.6 `reference` blocks
+
+A `reference_block` declares a read-only UTxO referenced (but not
+consumed) by the transaction.
+
+### Fields
+
+| Field        | Required | Type    | Meaning |
+| ------------ | -------- | ------- | ------- |
+| `ref`        | required | `UtxoRef` | The referenced UTxO. |
+| `datum_is`   | optional | type    | The expected datum type. When present, property access on the reference identifier (e.g. `oracle.price`) is typed against this type. |
+
+### Name
+
+Every `reference_block` carries a mandatory identifier, binding a symbol
+of kind *reference* in the tx scope.
+
+## 7.7 `signers` blocks
+
+A `signers_block` declares additional required signers for the
+transaction:
+
+```tx3
+signers {
+    Authority,
+    co_signer,
+}
+```
+
+Each entry is a `data_expr` that MUST evaluate to an *address-like* value
+(a party, a policy with a hash, a hex string, or an expression of type
+`Address` / `Bytes`).
+
+The block MAY be empty. At most one `signers_block` per `tx_def` is
+RECOMMENDED; the meaning of multiple `signers_block`s is the union of
+their entries.
+
+## 7.8 `validity` blocks
+
+A `validity_block` declares the slot range in which the transaction is
+valid:
+
+```tx3
+validity {
+    since_slot: 1000,
+    until_slot: 2000,
+}
+```
+
+Both fields are optional. When present, each is a `data_expr` of type
+`Int`. At most one `validity_block` per `tx_def` is RECOMMENDED.
+
+## 7.9 `mint` and `burn` blocks
+
+A `mint_block` declares assets minted by the transaction; a `burn_block`
+declares assets burnt. They share the field grammar of `mint_block_field`.
+
+### Fields
+
+| Field      | Required | Type        | Meaning |
+| ---------- | -------- | ----------- | ------- |
+| `amount`   | required | `AnyAsset`  | The asset value minted or burnt. |
+| `redeemer` | optional | any         | A redeemer to attach to the underlying minting policy. |
+
+Multiple `mint_block`s and `burn_block`s MAY appear in a single `tx_def`;
+each declares one independent mint/burn directive.
+
+## 7.10 `metadata` blocks
+
+A `metadata_block` attaches metadata entries to the transaction:
+
+```tx3
+metadata {
+    721: "Some payload",
+    42:  0xdeadbeef,
+}
+```
+
+Each entry's key MUST be an integer expression (§6.5). Each entry's
+value, when a literal `string_literal` or `hex_string`, MUST have byte
+length ≤ 64 (§6.5). Multiple `metadata_block`s in one `tx_def` are
+RECOMMENDED against; their meaning is the union of all entries.
+
+## 7.11 `locals` blocks
+
+A `locals_block` introduces named expressions visible in the rest of the
+tx body:
+
+```tx3
+locals {
+    total: source - fees,
+    refund: source - Ada(quantity),
+}
+```
+
+Each `locals_assign` binds a symbol of kind *local-expr* in the tx scope.
+The bound expression is substituted at each use site (modulo
+re-evaluation rules at resolution time, which are out of scope for this
+specification).
+
+A name introduced by a `locals_assign` MUST NOT collide with any
+parameter, input name, named output, or reference name in the same tx
+scope (§6.2).
+
+## 7.12 `collateral` blocks
+
+A `collateral_block` declares UTxO(s) supplied as collateral for
+script-bearing transactions on chains that require it.
+
+### Fields
+
+| Field        | Required | Type    | Meaning |
+| ------------ | -------- | ------- | ------- |
+| `from`       | optional | *party* / `Address` | Credential supplying the collateral. |
+| `min_amount` | optional | `AnyAsset` | Lower bound on the collateral value. |
+| `ref`        | optional | `UtxoRef` | Explicit collateral UTxO. |
+
+A `collateral_block` has no name. Multiple blocks MAY appear in one
+`tx_def`; each declares one independent collateral input.
+
+The use of collateral is chain-dependent. On chains that do not require
+collateral, conforming compilers SHOULD warn when a `collateral_block`
+appears.
+
+## 7.13 Top-level definitions
+
+### 7.13.1 `env`
+
+```tx3
+env {
+    network: Bytes,
+    treasury: Address,
+}
+```
+
+`env` fields are typed external inputs supplied at compile or resolution
+time. They are in scope everywhere except inside type definitions. They
+MUST be referenced by name only; arithmetic and property access work on
+them according to their declared type.
+
+### 7.13.2 `asset`
+
+```tx3
+asset MyToken = 0xabcd. "MyToken";
+```
+
+Binds `MyToken` to the asset class `(policy, asset_name)` where both
+arguments have type `Bytes`. Used either as a value-producing constructor
+(`MyToken(100)` is an `AnyAsset`) or as an identifier in
+`AnyAsset`-typed expressions.
+
+When applied as a constructor, an asset identifier `A` takes one argument
+of type `Int` and yields a value of type `AnyAsset` whose `policy` and
+`asset_name` are those declared by `A`.
+
+### 7.13.3 `party`
+
+```tx3
+party Alice;
+```
+
+Declares an abstract participant. A `party` is supplied a concrete
+address at resolution time. In `tx` bodies, a party identifier is
+acceptable wherever an `Address`-typed expression is expected (most
+notably in `from`, `to`, `signers`).
+
+### 7.13.4 `policy`
+
+```tx3
+policy TimeLock = 0x6b9c...;
+
+policy MyPolicy {
+    hash:   0xabcd...,
+    script: some_script_value,
+    ref:    some_ref,
+}
+```
+
+A `policy_def_assign` form fixes the policy's hash to a literal hex
+string. A `policy_def_constructor` form derives the policy from any
+subset of `hash`, `script`, and `ref` expressions.
+
+A `policy` identifier may be used as a *party-like* value (in `from`,
+`to`, `signers`), in which case it denotes the script credential
+implied by the policy.
+
+The semantics of `script` and `ref` fields are chain-specific and are
+described in §8 for Cardano targets.
+
+## 7.14 Cross-block constraints
+
+Within a single `tx_def`, the following requirements apply across blocks:
+
+- Each named symbol (input, reference, named output, local) MUST be
+  uniquely named within the tx scope (§6.2).
+- At least one `output_block`, `mint_block`, `burn_block`, `signers_block`,
+  `metadata_block`, `validity_block`, or chain-specific block SHOULD be
+  present; a `tx_def` with no body blocks is syntactically valid but
+  rarely useful.
+- Value balancing (the sum of inputs and mints equals the sum of outputs,
+  burns, and fees) is not enforced by the source language. It is the
+  resolver's responsibility (per TRP) and SHOULD be a runtime error of
+  the resolver, not a static-semantic error of this specification.

--- a/specs/v1beta0/08-cardano-extensions.md
+++ b/specs/v1beta0/08-cardano-extensions.md
@@ -1,0 +1,177 @@
+# 8. Cardano extensions
+
+The `cardano::` namespace introduces transaction-body blocks that are
+specific to the Cardano family of chains. These constructs are first-class
+in `v1beta0` but do not participate in the chain-agnostic core (§7).
+
+A `cardano_block` (per §4.6.10) selects exactly one of the inner forms
+below.
+
+## 8.1 Namespace grammar
+
+```
+cardano_inner ::=
+      cardano_stake_delegation_certificate
+    | cardano_vote_delegation_certificate
+    | cardano_withdrawal_block
+    | cardano_plutus_witness_block
+    | cardano_native_witness_block
+    | cardano_treasury_donation_block
+    | cardano_publish_block
+```
+
+Each occurrence is introduced by the prefix `cardano::`.
+
+## 8.2 Conformance scope
+
+A compiler that declares conformance with the Cardano target MUST
+accept every construct in this section. A compiler that targets a chain
+other than Cardano MAY reject every `cardano::*` block; if it does, it
+MUST do so with a clear diagnostic naming the chain mismatch.
+
+## 8.3 Withdrawal
+
+```
+cardano_withdrawal_block ::=
+    "cardano" "::" "withdrawal" "{" (withdrawal_field ",")+ "}"
+
+withdrawal_field ::=
+      "from"     ":" data_expr
+    | "amount"   ":" data_expr
+    | "redeemer" ":" data_expr
+```
+
+| Field      | Required | Type       | Meaning |
+| ---------- | -------- | ---------- | ------- |
+| `from`     | required | *party* / *policy* / `Address` | The stake credential being withdrawn from. |
+| `amount`   | required | `Int`      | The amount, in lovelace, being withdrawn. |
+| `redeemer` | optional | any        | Redeemer for a script stake credential. |
+
+A `withdrawal_block` MUST include at least the `from` and `amount`
+fields.
+
+## 8.4 Plutus witness
+
+```
+cardano_plutus_witness_block ::=
+    "cardano" "::" "plutus_witness" "{" (plutus_witness_field ",")+ "}"
+
+plutus_witness_field ::=
+      "version" ":" data_expr
+    | "script"  ":" data_expr
+```
+
+| Field     | Required | Type   | Meaning |
+| --------- | -------- | ------ | ------- |
+| `version` | optional | `Int`  | The Plutus language version (e.g. 1, 2, 3). |
+| `script`  | optional | `Bytes` | Inline Plutus script. |
+
+A `plutus_witness_block` MUST include at least one field. At resolution
+time, the supplied fields constitute a script witness attached to
+script-using inputs, mints, or certificates that require one.
+
+## 8.5 Native witness
+
+```
+cardano_native_witness_block ::=
+    "cardano" "::" "native_witness" "{" (native_witness_field ",")+ "}"
+
+native_witness_field ::=
+    "script" ":" data_expr
+```
+
+| Field    | Required | Type    | Meaning |
+| -------- | -------- | ------- | ------- |
+| `script` | required | `Bytes` | Inline native (multi-sig) script. |
+
+## 8.6 Treasury donation
+
+```
+cardano_treasury_donation_block ::=
+    "cardano" "::" "treasury_donation" "{" "coin" ":" data_expr "," "}"
+```
+
+| Field  | Required | Type  | Meaning                                   |
+| ------ | -------- | ----- | ----------------------------------------- |
+| `coin` | required | `Int` | The donation amount in lovelace. |
+
+## 8.7 Stake-delegation certificate
+
+```
+cardano_stake_delegation_certificate ::=
+    "cardano" "::" "stake_delegation_certificate" "{"
+        (record_constructor_field ",")*
+    "}"
+```
+
+The block syntactically takes a sequence of `record_constructor_field`
+entries (§4.4). The fields recognised by `v1beta0` are:
+
+| Field   | Required | Type     | Meaning |
+| ------- | -------- | -------- | ------- |
+| `pool`  | required | `Bytes` / *policy* / *party* | Pool ID being delegated to. |
+| `stake` | required | *party* / *policy* / `Address` | The stake credential delegating. |
+
+Implementations SHOULD reject this block if the required fields are
+absent. Lowering of this certificate is implementation-defined in
+`v1beta0`; conforming compilers MAY emit a "not yet supported"
+diagnostic until the corresponding TIR directive is finalised.
+
+## 8.8 Vote-delegation certificate
+
+```
+cardano_vote_delegation_certificate ::=
+    "cardano" "::" "vote_delegation_certificate" "{"
+        "drep"  ":" data_expr ","
+        "stake" ":" data_expr ","
+    "}"
+```
+
+| Field   | Required | Type     | Meaning |
+| ------- | -------- | -------- | ------- |
+| `drep`  | required | `Bytes` / *party* / *policy* | The DRep being delegated to. |
+| `stake` | required | *party* / *policy* / `Address` | The stake credential delegating. |
+
+Both fields MUST be present (enforced by the grammar above).
+
+## 8.9 Publish (reference script)
+
+```
+cardano_publish_block ::=
+    "cardano" "::" "publish" identifier? "{" (publish_field ",")* "}"
+
+publish_field ::=
+      "to"      ":" data_expr
+    | "amount"  ":" data_expr
+    | "datum"   ":" data_expr
+    | "version" ":" data_expr
+    | "script"  ":" data_expr
+```
+
+| Field     | Required | Type    | Meaning |
+| --------- | -------- | ------- | ------- |
+| `to`      | required | *party* / *policy* / `Address` | Recipient of the publish output. |
+| `amount`  | optional | `AnyAsset` | Value attached to the publish output. If absent, the resolver SHOULD attach the minimum required value (§7.5). |
+| `datum`   | optional | any (custom type) | A datum to attach. |
+| `version` | optional | `Int`   | The Plutus language version when publishing a Plutus script. |
+| `script`  | required | `Bytes` | The script bytes to be published as a reference script. |
+
+The optional `identifier` names the publish output for later reference,
+following the same rules as `output_block` names (§7.3).
+
+A `publish` block produces a single transaction output whose
+reference-script slot is set to the supplied `script`. The kind of
+script (native vs Plutus, and which Plutus version) is determined by the
+presence and value of `version`.
+
+## 8.10 Cross-block interaction
+
+- `cardano::plutus_witness` and `cardano::native_witness` blocks attach
+  to the surrounding transaction as a whole; the resolver pairs them
+  with the script-using inputs, mints, certificates, or withdrawals
+  that require them.
+- `cardano::withdrawal` and `cardano::*_delegation_certificate` blocks
+  are independent directives; multiple of each MAY appear in one
+  `tx_def`.
+- A `cardano::publish` block produces a transaction output in addition
+  to any declared `output_block`s; it does not replace them.

--- a/specs/v1beta0/09-conformance.md
+++ b/specs/v1beta0/09-conformance.md
@@ -1,0 +1,116 @@
+# 9. Conformance
+
+This section defines what it means for a Tx3 source program and a Tx3
+compiler to conform to `v1beta0` of this specification.
+
+## 9.1 Conforming source program
+
+A *conforming Tx3 program* is a UTF-8-encoded source file (or set of
+source files) that satisfies every MUST and MUST NOT in §3–§8. In
+particular, a conforming program:
+
+- contains only tokens defined in §3;
+- parses as a `program` under the grammar of §4;
+- satisfies the type rules of §5 and the static-semantic rules of §6;
+- uses each `tx`-body block according to §7;
+- uses each `cardano::*` block according to §8 (when targeting Cardano).
+
+A program that uses `bitcoin::` syntax (§4.6.10) is not a conforming
+program under `v1beta0`. Programs MAY use the syntax to anticipate
+future Bitcoin support, but they MUST NOT expect that support from a
+`v1beta0` compiler.
+
+## 9.2 Conforming compiler
+
+A *conforming Tx3 compiler* is a software artefact that, given a Tx3
+source file:
+
+1. **MUST** report no diagnostics, beyond optional warnings, when given a
+   conforming program. The program MUST be processed up to and including
+   the static-semantic phase (§2.5) without rejection.
+2. **MUST** emit at least one diagnostic in the appropriate category
+   (§6.9) for any program that violates a MUST or MUST NOT from §3–§8.
+3. **MUST** preserve the meaning of every conforming program when it
+   produces output. The lowering target (TIR or otherwise) is out of
+   scope for `v1beta0`, but the compiler MUST NOT silently alter the
+   program's declared shape.
+
+A conforming compiler MAY:
+
+- Emit additional diagnostics, warnings, or lints beyond those required.
+- Support source-level features beyond those defined here, provided
+  every conforming program continues to be accepted with the meaning
+  specified.
+- Refuse `cardano::*` blocks if it does not target Cardano (§8.2). It
+  MUST emit a clear diagnostic explaining the refusal.
+
+A conforming compiler MUST NOT:
+
+- Accept a non-conforming program as conforming.
+- Re-interpret the meaning of an existing construct in a way that
+  contradicts §5–§8.
+- Use the `bitcoin::` namespace (§4.6.10) to attach behaviour without a
+  separate specification authorising it.
+
+## 9.3 Extensions
+
+The specification leaves the following extension points open:
+
+- **The `bitcoin::` namespace.** Reserved; not defined by `v1beta0`.
+- **Chain-specific extensions beyond Cardano.** New namespaces MAY be
+  introduced by future versions, in dedicated sections analogous to §8.
+- **Built-in functions and properties.** Future versions MAY add
+  built-ins (§5.6, §5.4). Added built-ins MUST NOT shadow names already
+  in use by conforming programs.
+
+A compiler that implements extensions SHOULD gate them behind an
+explicit opt-in (a command-line flag, a manifest field, or similar) and
+SHOULD reject extension-using programs when the opt-in is not present.
+
+## 9.4 Versioning
+
+Implementations SHOULD report the highest specification version they
+conform to. When a future version of this specification introduces a
+breaking change relative to `v1beta0`, that future version lives in a
+new sibling directory under `specs/` and conformance with it is a
+separate, distinct claim.
+
+A compiler MAY conform to more than one version simultaneously, in
+which case it SHOULD provide a mechanism (e.g. a per-file directive or a
+manifest field) for source programs to select the intended version.
+
+## 9.5 Known divergences from the reference implementation
+
+The following items are tracked divergences between this specification
+and the reference implementation in
+[`tx3/crates/tx3-lang`](../../crates/tx3-lang/) at the time `v1beta0`
+was written. They are listed here so that implementers can predict the
+direction of upcoming changes. The specification is normative; the
+implementation will be brought into alignment.
+
+1. **Multiple `env`, `signers`, `validity`, or `metadata` blocks.** The
+   reference parser accepts more than one of each, with the AST taking
+   only one. This specification declares "RECOMMENDED at most one"
+   (§7.7, §7.8, §7.10) and leaves any tightening to a future version.
+2. **Tuple-form variant constructors.** §5.3.2 forbids construction of
+   tuple-form variant cases pending a defined construction syntax. The
+   reference parser does not currently provide such syntax either.
+3. **Hex-string literals of odd length.** Behaviour is
+   implementation-defined (§3.5.3). The reference implementation
+   currently accepts them silently.
+4. **`bitcoin::` namespace.** The reference parser parses
+   `bitcoin :: identifier` but the analyzer has no support for it
+   (§4.6.10). This specification reserves the namespace; the
+   implementation SHOULD reject use with a clear message.
+5. **`Address`-typed primitive literals.** `Address` is a primitive type
+   (§5.1) but `v1beta0` defines no literal syntax for it. Values of
+   type `Address` are produced by parties, policies, env fields, or
+   parameters, or by string/hex coercion at resolution time.
+6. **Implicit `Ada` semantics.** The implicit `asset Ada = …;` (§5.8)
+   is part of the reference compiler's behaviour. The specific policy
+   and asset-name attached to `Ada` are chain-defined and are not part
+   of the source language; they are documented in the resolver
+   specification.
+
+When a future patch of `v1beta0` is published, items resolved upstream
+will be removed from this list.

--- a/specs/v1beta0/README.md
+++ b/specs/v1beta0/README.md
@@ -1,0 +1,42 @@
+# Tx3 Language Specification — `v1beta0`
+
+> **Status:** Beta. The language surface described here is stable enough to
+> implement against, but is not frozen. Breaking changes will result in a new
+> version directory rather than in-place edits.
+
+## Table of contents
+
+1. [Introduction](01-introduction.md) — scope, conformance terminology, document conventions.
+2. [Domain model](02-domain-model.md) — abstract entities the language describes.
+3. [Lexical structure](03-lexical-structure.md) — source encoding, tokens, literals, keywords.
+4. [Syntactic grammar](04-syntactic-grammar.md) — EBNF for the full language.
+5. [Type system](05-type-system.md) — primitive, compound, and user-defined types.
+6. [Static semantics](06-static-semantics.md) — scoping, name resolution, type checking, validation rules.
+7. [Transaction semantics](07-transaction-semantics.md) — meaning of each `tx`-body block.
+8. [Cardano extensions](08-cardano-extensions.md) — the `cardano::` block namespace.
+9. [Conformance](09-conformance.md) — what it means to conform to this specification.
+
+## Reading order
+
+Sections are designed to be read in order. Each section assumes the previous
+ones. Forward references are used sparingly; where they appear they are
+explicit (e.g. "see §6.3").
+
+## Relationship to the reference implementation
+
+This document is the normative definition of `v1beta0`. The reference
+implementation lives in
+[`tx3/crates/tx3-lang`](../../crates/tx3-lang/) and currently uses a
+[Pest](https://pest.rs/) grammar at
+[`tx3/crates/tx3-lang/src/tx3.pest`](../../crates/tx3-lang/src/tx3.pest)
+together with the Rust modules `ast.rs`, `analyzing.rs`, `cardano.rs`, and
+`lowering.rs`. Pest is a parser-generator detail; the grammar in §4 is given
+in EBNF and is parser-agnostic.
+
+Known divergences between this specification and the reference implementation,
+where any exist, are listed in [§9](09-conformance.md).
+
+## Change log
+
+- `v1beta0` — initial specification, transcribed from the reference
+  implementation at the `tx3-lang/tx3` v0.17 line.


### PR DESCRIPTION
## Summary

Introduces the first **normative specification** of the high-level Tx3 source language, under `specs/v1beta0/`.

- Top-level `specs/README.md` indexes versions and frames the spec as the source of truth.
- Versioned subdirectory `specs/v1beta0/` matches the convention used by sibling specs (`trp/v1beta0/`, `tii/v1beta0/`, planned `tir/specs/v1beta0/`).
- Split into 9 chapters + a per-version README, ~2000 lines of prose.

### Scope

Covers the high-level surface language:

1. Introduction — scope, RFC 2119 conformance, EBNF notation, versioning policy.
2. Domain model — abstract entities (non-normative).
3. Lexical structure — tokens, literals, keywords.
4. Syntactic grammar — full EBNF derived from `tx3.pest`.
5. Type system — primitives, `List`/`Map`, records/variants/aliases, operators, built-ins.
6. Static semantics — scoping, name resolution, type checking, metadata rules, error catalogue.
7. Transaction semantics — per-block meaning, top-level def meaning, cross-block constraints.
8. Cardano extensions — `cardano::` namespace (withdrawal, plutus/native witness, certificates, treasury, publish).
9. Conformance — program/compiler conformance, extensions, known divergences.

### Out of scope

- TIR — specified separately at [`tx3-lang/tir`](https://github.com/tx3-lang/tir).
- TRP, TII, codegen frontends, `trix`.
- Formal mathematical semantics.

### Source-of-truth migration

The spec is derived from the current pest grammar and Rust analyzer at the v0.17 line. Going forward it is intended to become **the** source of truth: where the spec disagrees with the reference implementation, the implementation will be brought into alignment. Tracked divergences are listed in [`specs/v1beta0/09-conformance.md` §9.5](specs/v1beta0/09-conformance.md):

- `bitcoin::` namespace reserved but unimplemented (parser would panic — spec marks programs using it as non-conforming).
- Tuple-form variant case constructors have grammar but no construction syntax.
- Multiple `signers` / `validity` / `metadata` blocks parsed but only last survives in AST.
- `Address` has no literal syntax.
- Odd-length hex strings: implementation-defined.
- Implicit `Ada` asset is part of compiler behaviour; policy/name is chain-defined.

## Test plan

Specifications don't have automated tests. Verification is by review:

- [ ] Every grammar production in §4 traces to a `tx3.pest` rule.
- [ ] Every MUST in §6 traces to an analyzer check in `analyzing.rs`.
- [ ] Every block kind in §7/§8 traces to an AST type in `ast.rs`/`cardano.rs`.
- [ ] Walk a representative example (`examples/transfer.tx3`, `examples/vesting.tx3`, `examples/list_concat.tx3`) against the spec to confirm every construct is covered.
- [ ] Confirm the version label `v1beta0` is the right call (matches sibling specs).
- [ ] Confirm the split-per-chapter file layout is preferred over a single `SPEC.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)