### PR TITLE
feat(tx3c): add decode verb, emit tir-json and diagnostics-format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3021,6 +3021,7 @@ dependencies = [
  "dotenv-parser",
  "handlebars",
  "hex",
+ "miette",
  "schemars",
  "serde",
  "serde_json",

--- a/bin/tx3c/Cargo.toml
+++ b/bin/tx3c/Cargo.toml
@@ -23,5 +23,6 @@ serde_json = "1.0.137"
 serde.workspace = true
 schemars = { version = "1.1.0", features = ["derive"] }
 anyhow = "1.0.100"
+miette = { version = "7.5.0", features = ["fancy"] }
 dotenv-parser = "0.1.3"
 walkdir = "2.5.0"

--- a/bin/tx3c/src/build.rs
+++ b/bin/tx3c/src/build.rs
@@ -1,6 +1,7 @@
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use std::path::PathBuf;
 
+use crate::diagnostics::{self, DiagnosticsFormat};
 use crate::tii;
 
 use std::str::FromStr;
@@ -40,6 +41,18 @@ fn profile_env_file(s: &str) -> Result<ProfileKV<PathBuf>, String> {
     ProfileKV::parse(s)
 }
 
+/// What `build` should produce. Multiple targets are additive. When the list
+/// is empty, `build` runs the front end (parse + analyze) and stops *before*
+/// lowering, writing no artifact — this is the "check" semantic (cf.
+/// `rustc --emit=metadata`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum EmitKind {
+    /// Transaction Invocation Interface JSON file (the default when `-o` is used).
+    Tii,
+    /// The lowered v1beta0 TIR of a single `--tx`, as JSON, to stdout.
+    TirJson,
+}
+
 #[derive(Parser)]
 pub struct Args {
     pub source: PathBuf,
@@ -47,8 +60,16 @@ pub struct Args {
     #[arg(short, long)]
     pub output: Option<PathBuf>,
 
-    #[arg(short, long, value_delimiter = ',')]
-    pub emit: Vec<String>,
+    #[arg(short, long, value_delimiter = ',', value_enum)]
+    pub emit: Vec<EmitKind>,
+
+    /// Transaction name; required by `--emit tir-json`.
+    #[arg(long)]
+    pub tx: Option<String>,
+
+    /// How analyzer diagnostics are rendered.
+    #[arg(long, value_enum, default_value_t = DiagnosticsFormat::Human)]
+    pub diagnostics_format: DiagnosticsFormat,
 
     #[arg(long)]
     pub protocol_scope: Option<String>,
@@ -76,13 +97,52 @@ pub struct Args {
 }
 
 pub fn run(args: Args) -> anyhow::Result<()> {
+    let emit_tii = args.emit.contains(&EmitKind::Tii);
+    let emit_tir_json = args.emit.contains(&EmitKind::TirJson);
+    let needs_lower = emit_tii || emit_tir_json;
+    let format = args.diagnostics_format;
+
     let mut ws = tx3_lang::Workspace::from_file(&args.source)?;
 
-    ws.parse()?;
+    // Parse + analyze (the front end). A parse failure is itself reported
+    // through the diagnostics channel so JSON consumers get a single,
+    // uniform contract regardless of which phase failed.
+    if let Err(e) = ws.parse() {
+        return diagnostics::report_fatal(format, e);
+    }
     ws.analyze()?;
+
+    let errors = ws
+        .analisis()
+        .map(|r| r.errors.clone())
+        .unwrap_or_default();
+
+    diagnostics::report_analysis(format, &errors)?;
+    if !errors.is_empty() {
+        // `report_analysis` already emitted JSON and (for JSON) exited; this
+        // path is the human branch.
+        anyhow::bail!("check failed with {} error(s)", errors.len());
+    }
+
+    // No artifact requested ⇒ this was a check; nothing left to do.
+    if !needs_lower {
+        return Ok(());
+    }
+
     ws.lower()?;
 
-    if args.emit.contains(&"tii".to_string()) {
+    if emit_tir_json {
+        let name = args
+            .tx
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("--emit tir-json requires --tx <NAME>"))?;
+        let tir = ws
+            .tir(name)
+            .ok_or_else(|| anyhow::anyhow!("transaction '{}' not found", name))?;
+        println!("{}", serde_json::to_string(tir)?);
+    }
+
+    if emit_tii {
         tii::emit_tii(args, &ws)?;
     }
 

--- a/bin/tx3c/src/decode.rs
+++ b/bin/tx3c/src/decode.rs
@@ -1,0 +1,70 @@
+//! `tx3c decode` — the reverse of `build`.
+//!
+//! `build` goes source → compiled artifact; `decode` goes compiled artifact →
+//! report, sharing the same `--emit` axis. The input is polymorphic by design:
+//! today a published `.tii`, but future compiled inputs slot into this one
+//! verb rather than spawning new ones (cf. `protoc --decode`).
+
+use clap::Parser;
+use std::path::PathBuf;
+
+use crate::build::EmitKind;
+use crate::tii::types::{BytesEncoding, TiiFile};
+
+#[derive(Parser)]
+pub struct Args {
+    /// A compiled TII artifact to decode.
+    #[arg(long)]
+    pub tii: PathBuf,
+
+    /// What to emit. Currently only `tir-json`.
+    #[arg(short, long, value_delimiter = ',', value_enum)]
+    pub emit: Vec<EmitKind>,
+
+    /// Transaction name to decode; required by `--emit tir-json`.
+    #[arg(long)]
+    pub tx: Option<String>,
+}
+
+pub fn run(args: Args) -> anyhow::Result<()> {
+    let bytes = std::fs::read(&args.tii)
+        .map_err(|e| anyhow::anyhow!("reading {}: {e}", args.tii.display()))?;
+    let tii: TiiFile = serde_json::from_slice(&bytes)
+        .map_err(|e| anyhow::anyhow!("parsing TII {}: {e}", args.tii.display()))?;
+
+    if !args.emit.contains(&EmitKind::TirJson) {
+        anyhow::bail!("nothing to decode: pass --emit tir-json");
+    }
+
+    let name = args
+        .tx
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("--emit tir-json requires --tx <NAME>"))?;
+
+    let envelope = &tii
+        .transactions
+        .get(name)
+        .ok_or_else(|| anyhow::anyhow!("transaction '{}' not found in TII", name))?
+        .tir;
+
+    let raw = match envelope.encoding {
+        BytesEncoding::Hex => hex::decode(&envelope.content)
+            .map_err(|e| anyhow::anyhow!("decoding hex TIR: {e}"))?,
+        BytesEncoding::Base64 => anyhow::bail!(
+            "interface TIR is base64-encoded, which this tx3c does not support; \
+             ask the publisher to re-publish"
+        ),
+    };
+
+    let version = tx3_tir::encoding::TirVersion::try_from(envelope.version.as_str())
+        .map_err(|e| anyhow::anyhow!("unsupported TIR version: {e}"))?;
+    let any = tx3_tir::encoding::from_bytes(&raw, version)
+        .map_err(|e| anyhow::anyhow!("decoding TIR: {e}"))?;
+    let tx3_tir::encoding::AnyTir::V1Beta0(tx) = any;
+
+    // Same shape as `build --emit tir-json`, so a consumer can't tell whether
+    // the TIR came from source or from a published artifact.
+    println!("{}", serde_json::to_string(&tx)?);
+
+    Ok(())
+}

--- a/bin/tx3c/src/diagnostics.rs
+++ b/bin/tx3c/src/diagnostics.rs
@@ -1,0 +1,120 @@
+//! Diagnostics rendering for `tx3c`.
+//!
+//! Two formats share one pipeline. `human` is for people running `tx3c`
+//! directly (miette's fancy report). `json` is the machine contract consumed
+//! by orchestrators such as `trix`, which reconstruct their own rendering from
+//! it. Its shape is part of the `tx3c` CLI contract; consumers gate on the
+//! `tx3c` binary version rather than an in-band marker, so changes here must
+//! be coordinated with a version bump (see `trix`'s `MIN_TX3C_VERSION`).
+
+use clap::ValueEnum;
+use miette::Diagnostic;
+use serde::Serialize;
+
+use tx3_lang::analyzing;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum DiagnosticsFormat {
+    Human,
+    Json,
+}
+
+#[derive(Serialize)]
+struct Span {
+    start: usize,
+    end: usize,
+}
+
+#[derive(Serialize)]
+struct DiagnosticJson {
+    severity: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    code: Option<String>,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    span: Option<Span>,
+}
+
+#[derive(Serialize)]
+struct DiagnosticsEnvelope {
+    diagnostics: Vec<DiagnosticJson>,
+}
+
+fn code_of(d: &dyn Diagnostic) -> Option<String> {
+    d.code().map(|c| c.to_string())
+}
+
+fn from_analysis_error(e: &analyzing::Error) -> DiagnosticJson {
+    let span = e.span();
+    // The dummy span is (0, 0); only emit a real one.
+    let span = (span.start != span.end).then(|| Span {
+        start: span.start,
+        end: span.end,
+    });
+
+    DiagnosticJson {
+        severity: "error",
+        code: code_of(e),
+        message: e.to_string(),
+        span,
+    }
+}
+
+fn print_json(diagnostics: Vec<DiagnosticJson>) {
+    let envelope = DiagnosticsEnvelope { diagnostics };
+    // Single line, stdout: the orchestrator captures this stream.
+    println!(
+        "{}",
+        serde_json::to_string(&envelope).expect("diagnostics serialize")
+    );
+}
+
+/// Report a phase failure that aborts the build (e.g. a parse error). In JSON
+/// mode this emits the uniform envelope and exits non-zero; in human mode it
+/// returns the error so the caller's `?` surfaces it normally.
+pub fn report_fatal(
+    format: DiagnosticsFormat,
+    err: tx3_lang::Error,
+) -> anyhow::Result<()> {
+    match format {
+        DiagnosticsFormat::Json => {
+            print_json(vec![DiagnosticJson {
+                severity: "error",
+                code: code_of(&err),
+                message: err.to_string(),
+                span: None,
+            }]);
+            std::process::exit(1);
+        }
+        DiagnosticsFormat::Human => Err(err.into()),
+    }
+}
+
+/// Report the analyzer's collected errors. In JSON mode the envelope is always
+/// emitted (even when empty) so consumers get a uniform contract, and the
+/// process exits non-zero when there are errors. In human mode a non-empty set
+/// is rendered with miette's fancy report; the caller still aborts afterwards.
+pub fn report_analysis(
+    format: DiagnosticsFormat,
+    errors: &[analyzing::Error],
+) -> anyhow::Result<()> {
+    match format {
+        DiagnosticsFormat::Json => {
+            let diagnostics = errors.iter().map(from_analysis_error).collect();
+            print_json(diagnostics);
+            if !errors.is_empty() {
+                std::process::exit(1);
+            }
+            Ok(())
+        }
+        DiagnosticsFormat::Human => {
+            if !errors.is_empty() {
+                let report = analyzing::AnalyzeReport {
+                    errors: errors.to_vec(),
+                };
+                eprintln!("{:?}", miette::Report::new(report));
+            }
+            Ok(())
+        }
+    }
+}

--- a/bin/tx3c/src/main.rs
+++ b/bin/tx3c/src/main.rs
@@ -2,6 +2,8 @@ use clap::{Parser, Subcommand};
 
 mod build;
 mod codegen;
+mod decode;
+mod diagnostics;
 mod tii;
 
 #[derive(Parser)]
@@ -18,6 +20,8 @@ enum Commands {
     Build(build::Args),
     /// Render codegen templates from a TII file
     Codegen(codegen::Args),
+    /// Decode a compiled artifact (the reverse of `build`)
+    Decode(decode::Args),
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -26,6 +30,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
         Commands::Build(args) => build::run(args)?,
         Commands::Codegen(args) => codegen::run(args)?,
+        Commands::Decode(args) => decode::run(args)?,
     }
 
     Ok(())


### PR DESCRIPTION
## What

Exposes the low-level Tx3 operations as `tx3c` CLI surface so `trix` can stop linking the `tx3-lang`/`tx3-tir` crates and delegate to the `tx3c` binary instead (driver/compiler split, cf. cargo↔rustc).

- **`build`**: `--diagnostics-format human|json` (machine contract, mirrors `rustc --error-format=json`); typed `--emit` accepting `tii` and `tir-json`; empty `--emit` = front-end-only "check" semantic (cf. `rustc --emit=metadata`).
- **`decode`** (new verb): the reverse pipeline — compiled artifact → report, same `--emit` axis; decodes a published `.tii`'s TIR to the same JSON shape as `build --emit tir-json`.
- New `diagnostics` module; adds `miette` (fancy) for human rendering.

No changes to the `tx3-*` library crates.

## Why

First half of the trix↔tx3c delegation work. See `trix`'s `design/004-toolchain-delegation.md` (in the companion trix PR).

## Release ordering

This must be released **first**. The companion `trix` PR (tx3-lang/trix) gates on `tx3c >= 0.18.0` and will be tagged only after this ships. This is a `feat` over released `0.17.0`, so release-plz should cut **`0.18.0`**.

## Verification

- `cargo build -p tx3c`, `cargo test -p tx3c` (no unit tests; builds clean).
- Manual: `tx3c build <src> --diagnostics-format json` (JSON diagnostics + non-zero exit on errors, no `.tii`), `tx3c build <src> --emit tir-json --tx <name>`, `tx3c decode --tii <f> --emit tir-json --tx <name>` (byte-identical to the build path; base64-unsupported error preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)