### PR TITLE
feat(tx3c): add json helper to the codegen renderer

### DIFF
--- a/bin/tx3c/src/codegen.rs
+++ b/bin/tx3c/src/codegen.rs
@@ -194,6 +194,25 @@ fn register_helpers(handlebars: &mut Handlebars<'_>) {
             },
         ),
     );
+
+    handlebars.register_helper(
+        "json",
+        Box::new(
+            |h: &Helper,
+             _: &Handlebars,
+             _: &HbContext,
+             _: &mut RenderContext,
+             out: &mut dyn Output| {
+                let param = h.param(0).ok_or_else(|| {
+                    handlebars::RenderErrorReason::ParamNotFoundForIndex("json", 0)
+                })?;
+                let rendered = serde_json::to_string(param.value())
+                    .expect("serializing a parsed JSON value cannot fail");
+                out.write(&rendered)?;
+                Ok(())
+            },
+        ),
+    );
 }
 
 fn register_templates(


### PR DESCRIPTION
## Summary
- Adds a `json` Handlebars helper to `tx3c codegen` that serializes any TII node to a compact JSON string.
- handlebars-rust renders JSON objects as the literal `[object]`; without this helper, codegen plugins cannot faithfully embed `tii.profiles` / `tii.environment` into generated bindings.

## Why
First PR in a fleet-wide codegen-plugin update. The four SDK `.trix/client-lib/` plugins are being ported/completed to embed profile + environment data; their render-fixture tests depend on a `tx3c` release built from this PR.

## Test plan
- [ ] `cargo build -p tx3c`
- [ ] Render a template using `{{{json tii.profiles}}}` and confirm the output is valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)