### PR TITLE
fix: accept empty map literals and stop panicking on unresolved struct types

### DIFF
--- a/crates/tx3-lang/src/analyzing.rs
+++ b/crates/tx3-lang/src/analyzing.rs
@@ -652,7 +652,12 @@ impl Analyzable for StructConstructor {
             Some(symbol) => {
                 bail_report!(Error::invalid_symbol("struct type", symbol, &self.r#type));
             }
-            _ => unreachable!(),
+            None => {
+                bail_report!(Error::not_in_scope(
+                    self.r#type.value.clone(),
+                    &self.r#type
+                ));
+            }
         };
 
         for case in type_def.cases.iter() {

--- a/crates/tx3-lang/src/parsing.rs
+++ b/crates/tx3-lang/src/parsing.rs
@@ -2766,6 +2766,16 @@ mod tests {
         }
     );
 
+    input_to_ast_check!(
+        MapConstructor,
+        "empty",
+        "{}",
+        MapConstructor {
+            fields: vec![],
+            span: Span::DUMMY,
+        }
+    );
+
     #[test]
     fn test_spans_are_respected() {
         let program = parse_well_known_example("spans");

--- a/crates/tx3-lang/src/tx3.pest
+++ b/crates/tx3-lang/src/tx3.pest
@@ -199,7 +199,7 @@ map_field = {
 }
 
 map_constructor = {
-    "{" ~  (map_field ~ ",")+ ~ "}"
+    "{" ~ (map_field ~ ",")* ~ map_field? ~ "}"
 }
 
 // input block


### PR DESCRIPTION
## Summary

Two related issues kept protocols with `Map<K, V>` fields from compiling when an empty map literal was needed:

1. **Parser**: `map_constructor` required at least one entry (`(map_field ~ ",")+`), so `{}` failed to parse with `expected [data_expr]`. Relaxed to `*` with an optional trailing field — same shape `list_constructor` already uses for the `[]` case.

2. **Analyzer**: `StructConstructor::analyze` panicked with `unreachable!()` when `self.r#type.symbol` was `None`. That's the path users hit by writing `Map {}` (a struct constructor whose type identifier doesn't resolve to any registered `TypeDef`) — the toolchain was crashing instead of emitting a diagnostic. Replaced the panic with `Error::not_in_scope`.

## Why this matters

Surfaced by the [`indigo-protocols`](https://github.com/open-tx3/indigo-protocols) protocol, which initializes a `Map<Int, LockedEntry>` field with `{}`. After this:

- `st_locked_amount: {}` parses and analyzes as an empty `MapConstructor`. `tx3c build` produces a TII for indigo's `main.tx3` (verified locally: 82 KB output).
- `Map {}` now yields `not in scope: Map` rather than a panic. The right syntax for an empty map is the bare `{}`.

## Test plan

- [x] `cargo test -p tx3-lang` — 151 tests pass (added one for the empty-map AST shape)
- [x] `target/debug/tx3c build protocols/indigo/indigo/main.tx3 --emit tii -o /tmp/indigo.tii` succeeds
- [x] `target/debug/tx3c build <map_lit.tx3 using Map {}>` reports `not in scope: Map` cleanly instead of panicking

🤖 Generated with [Claude Code](https://claude.com/claude-code)