### PR TITLE
docs(spec): introduce doc-comments in v1beta0

### DIFF
--- a/crates/tx3-lang/src/tx3.pest
+++ b/crates/tx3-lang/src/tx3.pest
@@ -44,7 +44,7 @@ parameter_list = { "(" ~ (parameter ~ ("," ~ parameter)* ~ ","?)? ~ ")" }
 
 // Asset definitions
 asset_def = {
-    docstring? ~ "asset" ~ identifier ~ "=" ~ data_expr ~ "." ~ data_expr ~ ";"
+    "asset" ~ identifier ~ "=" ~ data_expr ~ "." ~ data_expr ~ ";"
 }
 
 // Party definitions

--- a/specs/v1beta0/03-lexical-structure.md
+++ b/specs/v1beta0/03-lexical-structure.md
@@ -33,16 +33,45 @@ between two identifiers, or between a keyword and an identifier).
 
 ## 3.3 Comments
 
-Tx3 has two kinds of comments. Both are equivalent to whitespace for the
-purposes of tokenisation.
+Tx3 has three kinds of comments.
 
-- **Line comments** begin with `//` and extend to the next line terminator
-  (exclusive).
+- **Line comments** begin with `//` (and not `///`) and extend to the next
+  line terminator (exclusive). Line comments are equivalent to whitespace
+  for the purposes of tokenisation.
 - **Block comments** begin with `/*` and extend to the next `*/`. Block
   comments **do not nest**: the first `*/` after the opening `/*` ends the
-  comment.
+  comment. Block comments are equivalent to whitespace.
+- **Doc-comments** begin with `///` and extend to the next line terminator
+  (exclusive). Doc-comments are **not** discarded: their textual content is
+  preserved and associated with the next syntactic construct (§3.3.1).
 
 A `/*` that is never closed is a syntax error.
+
+### 3.3.1 Doc-comments
+
+The textual content of a doc-comment is the substring after the leading
+`///`, with at most one immediately following space (U+0020) stripped. One
+or more *consecutive* doc-comment lines — separated only by whitespace —
+form a single *docstring*; the per-line contents are joined with a single
+U+000A (LF) in source order.
+
+A docstring MAY appear immediately before any of the following constructs,
+where it becomes the *documentation string* of that construct:
+
+- a `party_def` (§4.2.3);
+- an `env_field` (§4.2.1);
+- a `parameter` of a `tx_def` (§4.2.6);
+- a `tx_def` (§4.2.6).
+
+A `///` line that does not immediately precede one of the constructs above
+is a syntax error. Conforming compilers MAY relax this restriction as an
+extension (§9.3), provided they continue to accept all conforming programs
+unchanged.
+
+The documentation string of a construct has no effect on parsing, type
+checking, or transaction semantics. It is metadata, intended for surfacing
+by downstream tooling (e.g. generated bindings, registry UIs, or the TII
+artefact described in the resolver specification).
 
 ## 3.4 Identifiers
 

--- a/specs/v1beta0/04-syntactic-grammar.md
+++ b/specs/v1beta0/04-syntactic-grammar.md
@@ -4,9 +4,14 @@ This section gives the complete context-free grammar of Tx3 in EBNF. The
 grammar covers syntax only; semantic restrictions (e.g. "metadata keys
 MUST be integers") live in §6 and §7.
 
-The notation is as defined in §1.3. Whitespace and comments (§3.2, §3.3) are
-implicitly permitted between any two adjacent grammar symbols and are not
-written into the productions.
+The notation is as defined in §1.3. Whitespace and non-doc comments (§3.2,
+§3.3) are implicitly permitted between any two adjacent grammar symbols and
+are not written into the productions. Doc-comments (§3.3.1) are **not**
+implicitly skipped: a `docstring` only matches where the grammar names it
+explicitly, and a `///` line in any other position is a syntax error.
+
+The `docstring` nonterminal is defined lexically in §3.3.1 and is included
+here only as a terminal placeholder.
 
 ## 4.1 Program
 
@@ -32,7 +37,7 @@ subject to the no-duplicate-definitions rule of §6.2.
 
 ```
 env_def     ::= "env" "{" (env_field ",")+ "}"
-env_field   ::= identifier ":" type
+env_field   ::= docstring? identifier ":" type
 ```
 
 The `env` block declares typed external inputs that are in scope throughout
@@ -51,7 +56,7 @@ name. Both MUST have type `Bytes` after analysis (§6.3).
 ### 4.2.3 Party
 
 ```
-party_def ::= "party" identifier ";"
+party_def ::= docstring? "party" identifier ";"
 ```
 
 A *party definition* introduces a participant name. Party definitions carry
@@ -109,9 +114,9 @@ Notes:
 ### 4.2.6 Transaction
 
 ```
-tx_def         ::= "tx" identifier parameter_list "{" tx_body_block* "}"
+tx_def         ::= docstring? "tx" identifier parameter_list "{" tx_body_block* "}"
 parameter_list ::= "(" (parameter ("," parameter)* ","?)? ")"
-parameter      ::= identifier ":" type
+parameter      ::= docstring? identifier ":" type
 ```
 
 A *transaction definition* declares a parameterised template. The


### PR DESCRIPTION
## Summary
Follow-up to #329. Documents the `///` doc-comment surface that #329 added to the parser/AST/TII.

- §3.3 (Lexical structure) gains a third comment kind. Unlike `//` and `/* */`, doc-comments are not discarded — their textual content is preserved as a *documentation string* attached to the next construct.
- §3.3.1 (new) defines the docstring concatenation rule (multiple consecutive `///` lines join with `\n`, one optional leading space stripped per line) and lists the four constructs that may carry one: `party_def`, `env_field`, `tx_def`, and tx `parameter`. A `///` outside those positions is a syntax error.
- §4 productions for those four constructs gain an optional leading `docstring`. The §4 preamble notes that, unlike whitespace and non-doc comments, doc-comments are **not** implicitly skipped between productions.

Also reverts a stray `docstring?` prefix on `asset_def` in the reference grammar (`crates/tx3-lang/src/tx3.pest`): `AssetDef::parse` does not consume a docstring, so accepting one in the grammar causes a runtime panic when an `///` is placed before an `asset`. This brings the reference implementation back in line with the spec's tight surface.

## Why
The implementation in #329 already gates docstrings to four specific positions; the spec needed to mirror that. Without this PR the spec contradicts the reference parser, which is one of the things §9.5 ("Known divergences") exists to track.

## Test plan
- [x] `cargo test -p tx3-lang` — 155 tests pass (including the four `input_to_ast_check!` doc-comment cases added in #329).
- [x] Manually verified that `/// doc\nasset Foo = …;` no longer parses (matches updated spec/grammar).
- [x] Read-through of §3.3, §3.3.1, and §4 for internal consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)