### PR TITLE
spec(v1beta0): specify policy reference-script attachment in the core

### DIFF
--- a/specs/v1beta0/04-syntactic-grammar.md
+++ b/specs/v1beta0/04-syntactic-grammar.md
@@ -82,7 +82,7 @@ policy_def_ref         ::= "ref"    ":" data_expr
 A *policy definition* either binds the policy to a literal hex-string
 identifier (the assign form) or constructs it from a set of named fields
 (the constructor form). The constructor form MAY include any subset of
-`hash`, `script`, and `ref`. Field-level semantics are specified in §7.10.
+`hash`, `script`, and `ref`. Field-level semantics are specified in §7.13.4.
 
 ### 4.2.5 Type
 

--- a/specs/v1beta0/07-transaction-semantics.md
+++ b/specs/v1beta0/07-transaction-semantics.md
@@ -306,8 +306,23 @@ A `policy` identifier may be used as a *party-like* value (in `from`,
 `to`, `signers`), in which case it denotes the script credential
 implied by the policy.
 
-The semantics of `script` and `ref` fields are chain-specific and are
-described in §8 for Cardano targets.
+A policy's script *executes* when the policy is used in a position that
+spends from or runs it: as the `from` of an `input_block`, or as the
+policy of an asset in a `mint` or `burn` block. Used only as an output
+recipient (the `to` of an `output_block`) or as a signer, the script
+does not execute.
+
+When a policy whose script lives at a `ref` is used in an executing
+position, that `ref` UTxO is referenced (but not consumed) by the
+transaction — the same read-only reference described in §7.6 — so the
+script is available for validation. Such references are deduplicated: a
+`ref` reached by several executing uses, or one that coincides with an
+explicit `reference` block (§7.6), is referenced once. A policy declared
+by hash alone contributes no such reference.
+
+How the `script` and `ref` *contents* are interpreted — the kind of
+script and how it is witnessed when not referenced — is chain-specific;
+for Cardano targets see §8.4 and §8.5.
 
 ### 7.13.5 `fn`
 


### PR DESCRIPTION
Documents the behavior shipped in #332 / #333 and closes a dangling forward-reference in the spec.

## Problem

§7.13.4 (`policy`) said *"the semantics of `script` and `ref` fields are chain-specific and are described in §8"* — but §8 never described them. The spec had no statement of what a policy's `ref` does.

## Approach

A ref-backed policy contributing a read-only reference is a **normal extended-UTxO artifact** — the same "referenced but not consumed" UTxO already defined chain-agnostically in §7.6. So it's specified in the **core (§7)**, not the Cardano section. Only the genuinely chain-specific residue — how the script contents are interpreted and witnessed — stays in §8.

## Changes

- **§7.13.4 (`policy`)** now states: a policy's script *executes* when used as an input's `from` or a `mint`/`burn` policy; in that case a `ref`-backed policy's `ref` UTxO is referenced (but not consumed), per §7.6, so the script is available for validation. Used only as an output recipient (`to`) or signer, it does not. Covers dedup (against §7.6 blocks and repeated uses) and the hash-only case. The remaining chain-specific pointer is narrowed to the script-kind/witness details (§8.4, §8.5).
- **§4.2.4** field-semantics cross-reference corrected from §7.10 (the *metadata* section — a pre-existing error) to §7.13.4.
- **§8 is unchanged** — no new subsection or renumber; the core now describes the behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)