### PR TITLE
feat(lang): capture a policy's ref when withdrawing from its credential

### DIFF
--- a/crates/tx3-lang/src/cardano.rs
+++ b/crates/tx3-lang/src/cardano.rs
@@ -130,7 +130,8 @@ impl IntoLower for WithdrawalField {
         ctx: &crate::lowering::Context,
     ) -> Result<Self::Output, crate::lowering::Error> {
         match self {
-            WithdrawalField::From(x) => x.into_lower(ctx),
+            // Withdrawing from a script stake credential runs its script.
+            WithdrawalField::From(x) => x.into_lower(&ctx.capturing_policy_refs()),
             WithdrawalField::Amount(x) => x.into_lower(ctx),
             WithdrawalField::Redeemer(x) => x.into_lower(ctx),
         }

--- a/crates/tx3-lang/src/lowering.rs
+++ b/crates/tx3-lang/src/lowering.rs
@@ -1136,6 +1136,8 @@ mod tests {
         assert!(txs["mint_hash_only"].references.is_empty());
         // output recipient only: script does not run, no reference input
         assert!(txs["send_to_policy"].references.is_empty());
+        // ref-backed withdrawal stake credential
+        assert_eq!(txs["withdraw"].references.len(), 1);
     });
 
     test_lowering!(withdrawal);

--- a/examples/policy_reference_script.tx3
+++ b/examples/policy_reference_script.tx3
@@ -114,3 +114,18 @@ tx send_to_policy(
         amount: Ada(quantity),
     }
 }
+
+// ref-backed policy as a withdrawal stake credential: script runs, ref UTxO
+// becomes a reference input
+tx withdraw() {
+    cardano::withdrawal {
+        from: Validator,
+        amount: 0,
+        redeemer: (),
+    }
+
+    output {
+        to: Receiver,
+        amount: Ada(0),
+    }
+}

--- a/examples/policy_reference_script.withdraw.tir
+++ b/examples/policy_reference_script.withdraw.tir
@@ -1,0 +1,105 @@
+{
+  "fees": {
+    "EvalParam": "ExpectFees"
+  },
+  "references": [
+    {
+      "UtxoRefs": [
+        {
+          "txid": [
+            171,
+            205,
+            239,
+            18,
+            52,
+            86,
+            120,
+            144,
+            171,
+            205,
+            239,
+            18,
+            52,
+            86,
+            120,
+            144,
+            171,
+            205,
+            239,
+            18,
+            52,
+            86,
+            120,
+            144,
+            171,
+            205,
+            239,
+            18,
+            52,
+            86,
+            120,
+            144
+          ],
+          "index": 0
+        }
+      ]
+    }
+  ],
+  "inputs": [],
+  "outputs": [
+    {
+      "address": {
+        "EvalParam": {
+          "ExpectValue": [
+            "receiver",
+            "Address"
+          ]
+        }
+      },
+      "datum": "None",
+      "amount": {
+        "Assets": [
+          {
+            "policy": "None",
+            "asset_name": "None",
+            "amount": {
+              "Number": 0
+            }
+          }
+        ]
+      },
+      "optional": false
+    }
+  ],
+  "validity": null,
+  "mints": [],
+  "burns": [],
+  "adhoc": [
+    {
+      "name": "withdrawal",
+      "data": {
+        "credential": {
+          "Bytes": [
+            171,
+            205,
+            239,
+            18,
+            52
+          ]
+        },
+        "amount": {
+          "Number": 0
+        },
+        "redeemer": {
+          "Struct": {
+            "constructor": 0,
+            "fields": []
+          }
+        }
+      }
+    }
+  ],
+  "collateral": [],
+  "signers": null,
+  "metadata": []
+}

--- a/specs/v1beta0/07-transaction-semantics.md
+++ b/specs/v1beta0/07-transaction-semantics.md
@@ -310,7 +310,8 @@ A policy's script *executes* when the policy is used in a position that
 spends from or runs it: as the `from` of an `input_block`, or as the
 policy of an asset in a `mint` or `burn` block. Used only as an output
 recipient (the `to` of an `output_block`) or as a signer, the script
-does not execute.
+does not execute. Chain extensions may define further executing
+positions (for Cardano, see §8.3).
 
 When a policy whose script lives at a `ref` is used in an executing
 position, that `ref` UTxO is referenced (but not consumed) by the

--- a/specs/v1beta0/08-cardano-extensions.md
+++ b/specs/v1beta0/08-cardano-extensions.md
@@ -50,6 +50,10 @@ withdrawal_field ::=
 A `withdrawal_block` MUST include at least the `from` and `amount`
 fields.
 
+Withdrawing from a script stake credential executes its script, so a
+`ref`-backed `policy` used as `from` is referenced (but not consumed) by
+the transaction, per §7.13.4.
+
 ## 8.4 Plutus witness
 
 ```


### PR DESCRIPTION
Extends the policy reference-script tracking (#332, #333) to `cardano::withdrawal`.

## Why

Withdrawing from a script stake credential runs that script — the same situation as spending via an input's `from` or minting/burning under a policy. So a `ref`-backed policy used as a withdrawal `from` should contribute its `ref` UTxO as a reference input.

## Change

`WithdrawalField::From` now lowers under `capturing_policy_refs()`, mirroring `MintBlockField::Amount` and `InputBlockField::From`. One line; the existing accumulator/drain handles the rest (withdrawals lower via `adhoc`, before the drain in `TxDef::into_lower`).

## Spec

The merged spec (#334) listed the executing positions as input `from` / mint / burn. Withdrawal is a Cardano construct, so:
- **§7.13.4** now notes chain extensions may define further executing positions.
- **§8.3 (Withdrawal)** states a `ref`-backed `from` is referenced per §7.13.4.

## Test

New `withdraw` example tx (`cardano::withdrawal { from: <ref-backed policy> }`) asserts one reference input. `cargo test -p tx3-lang`: 167 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)