### PR TITLE
fix(lang): resolve policy field references for lowering

### DIFF
--- a/crates/tx3-lang/src/analyzing.rs
+++ b/crates/tx3-lang/src/analyzing.rs
@@ -1558,6 +1558,19 @@ impl Analyzable for Program {
 
         let scope_rc = self.scope.as_mut().unwrap();
 
+        // Policies were tracked before analysis, so the symbol table holds
+        // pre-analysis clones whose field expressions (e.g. `hash`/`ref`
+        // referencing an env var) carry no resolved symbols. Lowering resolves a
+        // policy through its symbol-table entry, so re-track the analyzed
+        // definitions here.
+        {
+            let scope =
+                Rc::get_mut(scope_rc).expect("scope should be unique during resolution");
+            for policy in self.policies.iter() {
+                scope.track_policy_def(policy);
+            }
+        }
+
         let (types, aliases) = resolve_types_and_aliases(scope_rc, &mut types, &mut aliases);
 
         // Functions may call other functions, and lowering inlines a callee's
@@ -1619,9 +1632,48 @@ pub fn analyze(ast: &mut Program) -> AnalyzeReport {
 
 #[cfg(test)]
 mod tests {
-    use crate::parsing::parse_well_known_example;
+    use crate::parsing::{parse_string, parse_well_known_example};
 
     use super::*;
+
+    // A policy is tracked in the symbol table before the policies are analyzed.
+    // Re-tracking the analyzed definitions must leave the stored policy with
+    // resolved field expressions, so a `hash`/`ref` referencing an env var is
+    // usable downstream (lowering resolves a policy through this entry).
+    #[test]
+    fn policy_def_fields_resolved_in_symbol_table() {
+        let mut program = parse_string(
+            r#"
+            env {
+                policy_hash: Bytes,
+                script_ref: UtxoRef,
+            }
+
+            policy P {
+                hash: policy_hash,
+                ref: script_ref,
+            }
+            "#,
+        )
+        .unwrap();
+
+        analyze(&mut program).ok().unwrap();
+
+        let symbol = program
+            .scope
+            .as_ref()
+            .unwrap()
+            .resolve("P")
+            .expect("policy P should be in scope");
+
+        match symbol {
+            Symbol::PolicyDef(policy) => assert!(
+                policy.is_resolved(),
+                "policy stored in the symbol table should have resolved fields"
+            ),
+            other => panic!("expected PolicyDef, got {other:?}"),
+        }
+    }
 
     #[test]
     fn test_program_with_semantic_errors() {


### PR DESCRIPTION
## Problem

A `policy` whose `hash`/`ref` references an `env` var (or any symbol) parses and analyzes cleanly but **fails to lower** with `MissingAnalyzePhase`:

```tx3
env { policy_hash: Bytes, script_ref: UtxoRef }
policy P { hash: policy_hash, ref: script_ref }   // ❌ MissingAnalyzePhase("policy_hash") at lowering
```

Only literal-field policies worked — which is why the ref-backed-policy feature (#332/#333/#335) passed its tests but couldn't be used by a real protocol, where the hash and ref are network-specific and supplied via `env`.

## Root cause

`Program::analyze` tracks every policy into the symbol table (`track_policy_def`) **before** running `self.policies.analyze()`. `track_policy_def` stores a *clone*, so the symbol-table copy keeps its field identifiers unresolved. Lowering resolves a referenced policy through that symbol-table entry (`Symbol::PolicyDef`), so its field expressions have no attached symbols → `MissingAnalyzePhase`.

## Fix

After `policies.analyze()`, re-track the analyzed policy definitions into the scope — the same re-track-after-analyze pattern `resolve_types_and_aliases` already uses. The symbol table then holds policies with resolved fields. One pass suffices (policy fields reference env/fn/other-policy symbols already in scope; no fixpoint needed).

## Test

`policy_def_fields_resolved_in_symbol_table` (in the `analyzing` module) analyzes a program with an env-backed policy `P`, resolves `P` from the program scope, and asserts the stored `PolicyDef::is_resolved()` — i.e. the symbol-table copy has resolved fields. Verified it fails without the fix and passes with it. `cargo test -p tx3-lang`: 168 passed, 0 failed.

This unblocks env-parameterized ref-backed policies (e.g. the GitHoney bounties simplification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)