### PR TITLE
docs(examples): add complex-type parameters example

### DIFF
--- a/examples/complex_type_params.tx3
+++ b/examples/complex_type_params.tx3
@@ -1,0 +1,65 @@
+// Demonstrates how complex (custom) types used as transaction parameters are
+// surfaced in the compiled TII under `components.schemas`:
+//
+//   - records      -> object schemas, referenced from params via `$ref`
+//   - nested types -> registered once and referenced recursively
+//   - variants     -> a tagged `oneOf`
+//   - aliases      -> inlined transparently (no schema of their own)
+//   - List<Record> -> an array whose `items` is a `$ref`
+
+party Sender;
+party Receiver;
+
+// Alias: inlined as its target (Int) wherever used; never its own schema.
+type Lovelace = Int;
+
+// Record: becomes an object schema with `policy_id` / `asset_name`.
+type AssetClass {
+    policy_id: Bytes,
+    asset_name: Bytes,
+}
+
+// Nested record: `asset` is a `$ref` to AssetClass; `price` inlines the alias.
+type Order {
+    asset: AssetClass,
+    price: Lovelace,
+}
+
+// Variant: a tagged union, emitted as `oneOf` over its cases.
+type Side {
+    Buy,
+    Sell {
+        min_price: Lovelace,
+    },
+}
+
+// Single record parameter plus a variant parameter.
+tx place(order: Order, side: Side) {
+    input source {
+        from: Sender,
+        min_amount: Ada(order.price),
+    }
+
+    output {
+        to: Receiver,
+        amount: Ada(order.price),
+    }
+
+    output {
+        to: Sender,
+        amount: source - Ada(order.price) - fees,
+    }
+}
+
+// List-of-records parameter: an array of `$ref`s to Order.
+tx place_many(orders: List<Order>, budget: Lovelace) {
+    input source {
+        from: Sender,
+        min_amount: Ada(budget),
+    }
+
+    output {
+        to: Sender,
+        amount: source - fees,
+    }
+}


### PR DESCRIPTION
## What

Add `examples/complex_type_params.tx3` — a single buildable example that
exercises custom types as transaction parameters, which is what drives the
TII `components.schemas` emission added in #337.

## Why

No example in `examples/` used a record/variant type as a `tx` parameter or
`env` field, so the new schema emission had zero end-to-end coverage there
(only `tii::schema` unit tests). The two existing files that take custom-type
params (`jpg.tx3`, `levvy.simple.tx3`) don't currently parse.

## Coverage in one file

- **Record param** — `Order` → object schema, referenced by `$ref`
- **Nested record** — `Order.asset: AssetClass` → recursive `$ref`, registered once
- **Variant param** — `Side` → tagged `oneOf`
- **Type alias** — `Lovelace = Int` → inlined transparently (no schema of its own)
- **`List<Record>`** — `place_many(orders: List<Order>)` → array whose `items` is a `$ref`

Verified: `tx3c build … --emit tii` yields
`components.schemas = { AssetClass, Order, Side }` with the expected `$ref`s and
`oneOf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
