### PR TITLE
chore: bump tx3-tir to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,9 +3037,9 @@ dependencies = [
 
 [[package]]
 name = "tx3-tir"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152e332c5ab744e8f17d54dfa4b6e3e177d5055141a1f37625303d4613277a72"
+checksum = "4bd8b43d04c3d116e901407cf4c6fa4949938f8904dddf7088cb97efcacd8bb2"
 dependencies = [
  "ciborium",
  "hex",

--- a/bin/tx3c/Cargo.toml
+++ b/bin/tx3c/Cargo.toml
@@ -12,7 +12,7 @@ homepage.workspace = true
 readme.workspace = true
 
 [dependencies]
-tx3-tir = "0.17.0"
+tx3-tir = "0.18.0"
 tx3-lang = { path = "../../crates/tx3-lang" }
 tx3-cardano = { path = "../../crates/tx3-cardano" }
 clap = { version = "4.5", features = ["derive"] }

--- a/bin/tx3c/src/tii/schema.rs
+++ b/bin/tx3c/src/tii/schema.rs
@@ -73,6 +73,14 @@ impl<'a> SchemaCtx<'a> {
                 "type": "object",
                 "additionalProperties": self.map_type(value)
             }),
+            // A tuple is a fixed-length, positionally-typed array.
+            ast::Type::Tuple(elements) => json!({
+                "type": "array",
+                "prefixItems": elements.iter().map(|t| self.map_type(t)).collect::<Vec<_>>(),
+                "items": false,
+                "minItems": elements.len(),
+                "maxItems": elements.len()
+            }),
             ast::Type::Custom(id) => self.map_custom(&id.value),
             ast::Type::Undefined => json!({"type": "null"}),
             ast::Type::Utxo => {

--- a/crates/tx3-cardano/Cargo.toml
+++ b/crates/tx3-cardano/Cargo.toml
@@ -17,7 +17,7 @@ pallas = { version = "1.0.0" }
 # pallas = { version = ">=1.0.0-alpha, <2.0.0", path = "../../../../txpipe/pallas/pallas" }
 # pallas = { git = "https://github.com/txpipe/pallas.git" }
 
-tx3-tir = "0.17.0"
+tx3-tir = "0.18.0"
 
 hex = "0.4.3"
 thiserror = "2.0.11"

--- a/crates/tx3-lang/Cargo.toml
+++ b/crates/tx3-lang/Cargo.toml
@@ -18,7 +18,7 @@ trait-variant = { workspace = true }
 hex = { workspace = true }
 serde = { workspace = true }
 
-tx3-tir = "0.17.0"
+tx3-tir = "0.18.0"
 
 miette = { version = "7.4.0", features = ["fancy"] }
 pest = { version = "2.7.15", features = ["miette-error", "pretty-print"] }

--- a/crates/tx3-resolver/Cargo.toml
+++ b/crates/tx3-resolver/Cargo.toml
@@ -13,7 +13,7 @@ homepage.workspace = true
 readme.workspace = true
 
 [dependencies]
-tx3-tir = "0.17.0"
+tx3-tir = "0.18.0"
 
 thiserror = { workspace = true }
 trait-variant = { workspace = true }


### PR DESCRIPTION
## Summary

Bumps `tx3-tir` `0.17.0` → `0.18.0` across the workspace (`tx3-lang`, `tx3-cardano`, `tx3-resolver`, `tx3c`). The 0.18 release ships the parametric tuple types (`Type::Tuple`, N-ary `Expression::Tuple`) that the merged tuple frontend (#341) is built against — `main` does not compile against `tx3-tir 0.17` without this.

Also adds the missing `ast::Type::Tuple` arm to the **tx3c** TII schema emitter (`bin/tx3c/src/tii/schema.rs`). That match is exhaustive over `ast::Type`, so it's part of the tuple feature surface; a tuple emits a fixed-length, positionally-typed JSON Schema array (`prefixItems` + `items: false` + pinned `min/maxItems`), matching the equivalent emitter in `tx3-mcp`.

## Verification

Full workspace builds against `tx3-tir 0.18.0` from crates.io; all test suites pass (`tx3-lang` 184, `tx3c` 23+84, others green).

## Release ordering

Follows the `tx3-tir 0.18.0` release. Merge, then release `tx3-lang` so downstream `tx3-lsp` / `tx3-mcp` / `registry` can bump to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
