### PR TITLE
ci: make CI green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -16,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@1.91
         with:
           components: rustfmt
@@ -27,6 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@1.91
         with:
           components: clippy
@@ -43,6 +54,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@1.91
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --all-targets --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/bin/tx3c/src/build.rs
+++ b/bin/tx3c/src/build.rs
@@ -112,10 +112,7 @@ pub fn run(args: Args) -> anyhow::Result<()> {
     }
     ws.analyze()?;
 
-    let errors = ws
-        .analisis()
-        .map(|r| r.errors.clone())
-        .unwrap_or_default();
+    let errors = ws.analisis().map(|r| r.errors.clone()).unwrap_or_default();
 
     diagnostics::report_analysis(format, &errors)?;
     if !errors.is_empty() {

--- a/bin/tx3c/src/codegen.rs
+++ b/bin/tx3c/src/codegen.rs
@@ -385,7 +385,7 @@ fn register_templates(
 }
 
 fn render_templates(handlebars: &Handlebars<'_>, data: &Value, output_dir: &Path) -> Result<()> {
-    for (name, _) in handlebars.get_templates() {
+    for name in handlebars.get_templates().keys() {
         let rendered = handlebars
             .render(name, data)
             .with_context(|| format!("rendering template {name}"))?;

--- a/bin/tx3c/src/decode.rs
+++ b/bin/tx3c/src/decode.rs
@@ -48,8 +48,9 @@ pub fn run(args: Args) -> anyhow::Result<()> {
         .tir;
 
     let raw = match envelope.encoding {
-        BytesEncoding::Hex => hex::decode(&envelope.content)
-            .map_err(|e| anyhow::anyhow!("decoding hex TIR: {e}"))?,
+        BytesEncoding::Hex => {
+            hex::decode(&envelope.content).map_err(|e| anyhow::anyhow!("decoding hex TIR: {e}"))?
+        }
         BytesEncoding::Base64 => anyhow::bail!(
             "interface TIR is base64-encoded, which this tx3c does not support; \
              ask the publisher to re-publish"

--- a/bin/tx3c/src/diagnostics.rs
+++ b/bin/tx3c/src/diagnostics.rs
@@ -47,7 +47,7 @@ fn code_of(d: &dyn Diagnostic) -> Option<String> {
 fn from_analysis_error(e: &analyzing::Error) -> DiagnosticJson {
     let span = e.span();
     // The dummy span is (0, 0); only emit a real one.
-    let span = (span.start != span.end).then(|| Span {
+    let span = (span.start != span.end).then_some(Span {
         start: span.start,
         end: span.end,
     });

--- a/bin/tx3c/src/diagnostics.rs
+++ b/bin/tx3c/src/diagnostics.rs
@@ -72,10 +72,7 @@ fn print_json(diagnostics: Vec<DiagnosticJson>) {
 /// Report a phase failure that aborts the build (e.g. a parse error). In JSON
 /// mode this emits the uniform envelope and exits non-zero; in human mode it
 /// returns the error so the caller's `?` surfaces it normally.
-pub fn report_fatal(
-    format: DiagnosticsFormat,
-    err: tx3_lang::Error,
-) -> anyhow::Result<()> {
+pub fn report_fatal(format: DiagnosticsFormat, err: tx3_lang::Error) -> anyhow::Result<()> {
     match format {
         DiagnosticsFormat::Json => {
             print_json(vec![DiagnosticJson {

--- a/bin/tx3c/src/tii/schema.rs
+++ b/bin/tx3c/src/tii/schema.rs
@@ -254,7 +254,10 @@ mod tests {
             schemas["Outer"]["properties"]["inner"]["$ref"],
             json!("#/components/schemas/Inner")
         );
-        assert_eq!(schemas["Inner"]["properties"]["x"]["type"], json!("integer"));
+        assert_eq!(
+            schemas["Inner"]["properties"]["x"]["type"],
+            json!("integer")
+        );
     }
 
     #[test]

--- a/crates/tx3-cardano/src/compile/mod.rs
+++ b/crates/tx3-cardano/src/compile/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 
 use pallas::{
     codec::{
@@ -805,33 +805,6 @@ fn compile_redeemers(
     } else {
         Ok(Some(primitives::Redeemers::Map(map)))
     }
-}
-
-/// Crawls the transaction body to find all the required scripts.
-fn infer_required_scripts(
-    compiled_body: &primitives::TransactionBody,
-) -> HashSet<primitives::Hash<28>> {
-    let mint_policies = compiled_body
-        .mint
-        .iter()
-        .flatten()
-        .map(|(p, _)| *p)
-        .collect::<Vec<_>>();
-
-    // TODO: evaluate inputs searching for script addresses
-
-    // TODO: evaluate withdrawals searching for script addresses
-
-    // TODO: other sources for scripts
-
-    // TODO: remove if script is already present via reference inputs
-
-    HashSet::from_iter(mint_policies)
-}
-
-fn find_script_for_hash(tx: &tir::Tx, hash: primitives::Hash<28>) -> Option<tir::Expression> {
-    // TODO: we need to track script symbols as part of the IR
-    todo!()
 }
 
 fn compile_adhoc_plutus_witness<const V: usize>(tx: &tir::Tx) -> Vec<PlutusScript<V>> {

--- a/crates/tx3-cardano/src/compile/mod.rs
+++ b/crates/tx3-cardano/src/compile/mod.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashSet};
 use pallas::{
     codec::{
         minicbor,
-        utils::{KeepRaw, MaybeIndefArray, NonEmptySet},
+        utils::{KeepRaw, NonEmptySet},
     },
     ledger::{
         primitives::{
@@ -824,11 +824,9 @@ fn infer_required_scripts(
 
     // TODO: other sources for scripts
 
-    let all_scripts = HashSet::from_iter(mint_policies);
-
     // TODO: remove if script is already present via reference inputs
 
-    all_scripts
+    HashSet::from_iter(mint_policies)
 }
 
 fn find_script_for_hash(tx: &tir::Tx, hash: primitives::Hash<28>) -> Option<tir::Expression> {

--- a/crates/tx3-cardano/src/lib.rs
+++ b/crates/tx3-cardano/src/lib.rs
@@ -1,3 +1,10 @@
+#![allow(
+    dead_code,
+    unused_variables,
+    irrefutable_let_patterns,
+    clippy::useless_conversion
+)]
+
 use std::collections::HashMap;
 
 pub mod coercion;

--- a/crates/tx3-cardano/src/lib.rs
+++ b/crates/tx3-cardano/src/lib.rs
@@ -1,10 +1,3 @@
-#![allow(
-    dead_code,
-    unused_variables,
-    irrefutable_let_patterns,
-    clippy::useless_conversion
-)]
-
 use std::collections::HashMap;
 
 pub mod coercion;
@@ -86,9 +79,7 @@ impl tx3_tir::compile::Compiler for Compiler {
     type Expression = tir::Expression;
 
     fn compile(&mut self, tir: &AnyTir) -> Result<CompiledTx, CompileError> {
-        let AnyTir::V1Beta0(tx) = tir else {
-            return Err(CompileError::UnsupportedTirVersion(tir.version()));
-        };
+        let AnyTir::V1Beta0(tx) = tir;
 
         let compiled_tx = compile::entry_point(tx, &self.pparams)?;
 

--- a/crates/tx3-cardano/src/tests.rs
+++ b/crates/tx3-cardano/src/tests.rs
@@ -80,10 +80,8 @@ fn address_to_bytes(address: &str) -> ArgValue {
 }
 
 fn wildcard_utxos(datum: Option<tir::Expression>) -> UtxoSet {
-    let tx_hash = hex::decode("267aae354f0d14d82877fa5720f7ddc9b0e3eea3cd2a0757af77db4d975ba81c")
-        .unwrap()
-        .try_into()
-        .unwrap();
+    let tx_hash =
+        hex::decode("267aae354f0d14d82877fa5720f7ddc9b0e3eea3cd2a0757af77db4d975ba81c").unwrap();
 
     let address = pallas::ledger::addresses::Address::from_bech32("addr1qx0rs5qrvx9qkndwu0w88t0xghgy3f53ha76kpx8uf496m9rn2ursdm3r0fgf5pmm4lpufshl8lquk5yykg4pd00hp6quf2hh2").unwrap().to_vec();
 

--- a/crates/tx3-lang/src/analyzing.rs
+++ b/crates/tx3-lang/src/analyzing.rs
@@ -1073,15 +1073,19 @@ impl Analyzable for MetadataBlockField {
     fn analyze(&mut self, parent: Option<Rc<Scope>>) -> AnalyzeReport {
         let mut report = self.key.analyze(parent.clone()) + self.value.analyze(parent.clone());
 
-        validate_metadata_key_type(&self.key)
+        if let Some(e) = validate_metadata_key_type(&self.key)
             .map_err(Error::MetadataInvalidKeyType)
             .err()
-            .map(|e| report.errors.push(e));
+        {
+            report.errors.push(e)
+        }
 
-        validate_metadata_value_size(&self.value)
+        if let Some(e) = validate_metadata_value_size(&self.value)
             .map_err(Error::MetadataSizeLimitExceeded)
             .err()
-            .map(|e| report.errors.push(e));
+        {
+            report.errors.push(e)
+        }
 
         report
     }
@@ -1148,7 +1152,7 @@ impl Analyzable for OutputBlock {
     fn analyze(&mut self, parent: Option<Rc<Scope>>) -> AnalyzeReport {
         validate_optional_output(self)
             .map(AnalyzeReport::from)
-            .unwrap_or_else(|| AnalyzeReport::default())
+            .unwrap_or_default()
             + self.fields.analyze(parent)
     }
 
@@ -1389,7 +1393,7 @@ impl Analyzable for FnDef {
     }
 
     fn is_resolved(&self) -> bool {
-        self.parameters.is_resolved() && self.body.as_ref().map_or(true, |b| b.is_resolved())
+        self.parameters.is_resolved() && self.body.as_ref().is_none_or(|b| b.is_resolved())
     }
 }
 
@@ -1422,7 +1426,7 @@ impl TxDef {
             }
         }
 
-        for (_, input) in self.inputs.iter().enumerate() {
+        for input in self.inputs.iter() {
             scope.track_input(&input.name, input.clone())
         }
 

--- a/crates/tx3-lang/src/analyzing.rs
+++ b/crates/tx3-lang/src/analyzing.rs
@@ -717,10 +717,7 @@ impl Analyzable for StructConstructor {
                 bail_report!(Error::invalid_symbol("struct type", symbol, &self.r#type));
             }
             None => {
-                bail_report!(Error::not_in_scope(
-                    self.r#type.value.clone(),
-                    &self.r#type
-                ));
+                bail_report!(Error::not_in_scope(self.r#type.value.clone(), &self.r#type));
             }
         };
 
@@ -843,7 +840,12 @@ impl Analyzable for crate::ast::FnCall {
             .symbol
             .as_ref()
             .and_then(|s| s.as_fn_def())
-            .map(|fn_def| (fn_def.name.value.clone(), fn_def.parameters.parameters.len()));
+            .map(|fn_def| {
+                (
+                    fn_def.name.value.clone(),
+                    fn_def.parameters.parameters.len(),
+                )
+            });
 
         if let Some((name, expected)) = signature {
             let got = self.args.len();
@@ -1387,8 +1389,7 @@ impl Analyzable for FnDef {
     }
 
     fn is_resolved(&self) -> bool {
-        self.parameters.is_resolved()
-            && self.body.as_ref().map_or(true, |b| b.is_resolved())
+        self.parameters.is_resolved() && self.body.as_ref().map_or(true, |b| b.is_resolved())
     }
 }
 
@@ -1608,8 +1609,7 @@ impl Analyzable for Program {
         // policy through its symbol-table entry, so re-track the analyzed
         // definitions here.
         {
-            let scope =
-                Rc::get_mut(scope_rc).expect("scope should be unique during resolution");
+            let scope = Rc::get_mut(scope_rc).expect("scope should be unique during resolution");
             for policy in self.policies.iter() {
                 scope.track_policy_def(policy);
             }

--- a/crates/tx3-lang/src/ast.rs
+++ b/crates/tx3-lang/src/ast.rs
@@ -845,10 +845,9 @@ impl DataExpr {
             DataExpr::HexString(_) => Some(Type::Bytes),
             DataExpr::StructConstructor(x) => x.target_type(),
             DataExpr::MapConstructor(x) => x.target_type(),
-            DataExpr::ListConstructor(x) => match x.target_type() {
-                Some(inner) => Some(Type::List(Box::new(inner))),
-                None => None,
-            },
+            DataExpr::ListConstructor(x) => {
+                x.target_type().map(|inner| Type::List(Box::new(inner)))
+            }
             DataExpr::TupleConstructor(x) => x.target_type(),
             DataExpr::AddOp(x) => x.target_type(),
             DataExpr::SubOp(x) => x.target_type(),

--- a/crates/tx3-lang/src/builtins/mod.rs
+++ b/crates/tx3-lang/src/builtins/mod.rs
@@ -171,7 +171,11 @@ mod tests {
             assert_eq!(def.name.value, b.name());
             assert_eq!(def.parameters.parameters.len(), b.signature().params.len());
             // Names are unique across the set.
-            assert!(names.insert(b.name()), "duplicate built-in name: {}", b.name());
+            assert!(
+                names.insert(b.name()),
+                "duplicate built-in name: {}",
+                b.name()
+            );
         }
     }
 }

--- a/crates/tx3-lang/src/builtins/mod.rs
+++ b/crates/tx3-lang/src/builtins/mod.rs
@@ -122,7 +122,7 @@ macro_rules! builtin_boilerplate {
                             $name,
                             stringify!($param),
                         )))?
-                        .into_lower(ctx)?;
+                        .lower(ctx)?;
                 )*
                 Ok(ir::Expression::EvalCompiler(Box::new(
                     ir::CompilerOp::$op $(( $( $oparg ),* ))?

--- a/crates/tx3-lang/src/cardano.rs
+++ b/crates/tx3-lang/src/cardano.rs
@@ -855,10 +855,7 @@ impl IntoLower for CardanoBlock {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        analyzing::analyze,
-        ast::{self, *},
-    };
+    use crate::{analyzing::analyze, ast::*};
     use pest::Parser;
 
     macro_rules! input_to_ast_check {

--- a/crates/tx3-lang/src/cardano.rs
+++ b/crates/tx3-lang/src/cardano.rs
@@ -125,15 +125,15 @@ impl Analyzable for WithdrawalBlock {
 impl IntoLower for WithdrawalField {
     type Output = ir::Expression;
 
-    fn into_lower(
+    fn lower(
         &self,
         ctx: &crate::lowering::Context,
     ) -> Result<Self::Output, crate::lowering::Error> {
         match self {
             // Withdrawing from a script stake credential runs its script.
-            WithdrawalField::From(x) => x.into_lower(&ctx.capturing_policy_refs()),
-            WithdrawalField::Amount(x) => x.into_lower(ctx),
-            WithdrawalField::Redeemer(x) => x.into_lower(ctx),
+            WithdrawalField::From(x) => x.lower(&ctx.capturing_policy_refs()),
+            WithdrawalField::Amount(x) => x.lower(ctx),
+            WithdrawalField::Redeemer(x) => x.lower(ctx),
         }
     }
 }
@@ -141,7 +141,7 @@ impl IntoLower for WithdrawalField {
 impl IntoLower for WithdrawalBlock {
     type Output = ir::AdHocDirective;
 
-    fn into_lower(
+    fn lower(
         &self,
         ctx: &crate::lowering::Context,
     ) -> Result<Self::Output, crate::lowering::Error> {
@@ -150,7 +150,7 @@ impl IntoLower for WithdrawalBlock {
             .ok_or_else(|| {
                 crate::lowering::Error::MissingRequiredField("from".to_string(), "WithdrawalBlock")
             })?
-            .into_lower(ctx)?;
+            .lower(ctx)?;
 
         let amount = self
             .find("amount")
@@ -160,11 +160,11 @@ impl IntoLower for WithdrawalBlock {
                     "WithdrawalBlock",
                 )
             })?
-            .into_lower(ctx)?;
+            .lower(ctx)?;
 
         let redeemer = self
             .find("redeemer")
-            .map(|r| r.into_lower(ctx))
+            .map(|r| r.lower(ctx))
             .transpose()?
             .unwrap_or(ir::Expression::None);
 
@@ -221,15 +221,15 @@ impl Analyzable for VoteDelegationCertificate {
 impl IntoLower for VoteDelegationCertificate {
     type Output = ir::AdHocDirective;
 
-    fn into_lower(
+    fn lower(
         &self,
         ctx: &crate::lowering::Context,
     ) -> Result<Self::Output, crate::lowering::Error> {
         Ok(ir::AdHocDirective {
             name: "vote_delegation_certificate".to_string(),
             data: HashMap::from([
-                ("drep".to_string(), self.drep.into_lower(ctx)?),
-                ("stake".to_string(), self.stake.into_lower(ctx)?),
+                ("drep".to_string(), self.drep.lower(ctx)?),
+                ("stake".to_string(), self.stake.lower(ctx)?),
             ]),
         })
     }
@@ -277,7 +277,7 @@ impl Analyzable for StakeDelegationCertificate {
 impl IntoLower for StakeDelegationCertificate {
     type Output = ir::AdHocDirective;
 
-    fn into_lower(
+    fn lower(
         &self,
         _ctx: &crate::lowering::Context,
     ) -> Result<Self::Output, crate::lowering::Error> {
@@ -294,13 +294,13 @@ pub enum PlutusWitnessField {
 impl IntoLower for PlutusWitnessField {
     type Output = (String, ir::Expression);
 
-    fn into_lower(
+    fn lower(
         &self,
         ctx: &crate::lowering::Context,
     ) -> Result<Self::Output, crate::lowering::Error> {
         match self {
-            PlutusWitnessField::Version(x, _) => Ok(("version".to_string(), x.into_lower(ctx)?)),
-            PlutusWitnessField::Script(x, _) => Ok(("script".to_string(), x.into_lower(ctx)?)),
+            PlutusWitnessField::Version(x, _) => Ok(("version".to_string(), x.lower(ctx)?)),
+            PlutusWitnessField::Script(x, _) => Ok(("script".to_string(), x.lower(ctx)?)),
         }
     }
 }
@@ -384,14 +384,14 @@ impl Analyzable for PlutusWitnessBlock {
 impl IntoLower for PlutusWitnessBlock {
     type Output = ir::AdHocDirective;
 
-    fn into_lower(
+    fn lower(
         &self,
         ctx: &crate::lowering::Context,
     ) -> Result<Self::Output, crate::lowering::Error> {
         let data = self
             .fields
             .iter()
-            .map(|x| x.into_lower(ctx))
+            .map(|x| x.lower(ctx))
             .collect::<Result<_, _>>()?;
 
         Ok(ir::AdHocDirective {
@@ -409,12 +409,12 @@ pub enum NativeWitnessField {
 impl IntoLower for NativeWitnessField {
     type Output = (String, ir::Expression);
 
-    fn into_lower(
+    fn lower(
         &self,
         ctx: &crate::lowering::Context,
     ) -> Result<Self::Output, crate::lowering::Error> {
         match self {
-            NativeWitnessField::Script(x, _) => Ok(("script".to_string(), x.into_lower(ctx)?)),
+            NativeWitnessField::Script(x, _) => Ok(("script".to_string(), x.lower(ctx)?)),
         }
     }
 }
@@ -492,14 +492,14 @@ impl Analyzable for NativeWitnessBlock {
 impl IntoLower for NativeWitnessBlock {
     type Output = ir::AdHocDirective;
 
-    fn into_lower(
+    fn lower(
         &self,
         ctx: &crate::lowering::Context,
     ) -> Result<Self::Output, crate::lowering::Error> {
         let data = self
             .fields
             .iter()
-            .map(|x| x.into_lower(ctx))
+            .map(|x| x.lower(ctx))
             .collect::<Result<_, _>>()?;
 
         Ok(ir::AdHocDirective {
@@ -548,11 +548,11 @@ impl Analyzable for TreasuryDonationBlock {
 impl IntoLower for TreasuryDonationBlock {
     type Output = ir::AdHocDirective;
 
-    fn into_lower(
+    fn lower(
         &self,
         ctx: &crate::lowering::Context,
     ) -> Result<Self::Output, crate::lowering::Error> {
-        let coin = self.coin.into_lower(ctx)?;
+        let coin = self.coin.lower(ctx)?;
 
         Ok(ir::AdHocDirective {
             name: "treasury_donation".to_string(),
@@ -570,29 +570,11 @@ pub enum CardanoPublishBlockField {
     Script(Box<DataExpr>),
 }
 
-impl CardanoPublishBlockField {
-    fn key(&self) -> &str {
-        match self {
-            CardanoPublishBlockField::To(_) => "to",
-            CardanoPublishBlockField::Amount(_) => "amount",
-            CardanoPublishBlockField::Datum(_) => "datum",
-            CardanoPublishBlockField::Version(_) => "version",
-            CardanoPublishBlockField::Script(_) => "script",
-        }
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CardanoPublishBlock {
     pub name: Option<Identifier>,
     pub fields: Vec<CardanoPublishBlockField>,
     pub span: Span,
-}
-
-impl CardanoPublishBlock {
-    pub(crate) fn find(&self, key: &str) -> Option<&CardanoPublishBlockField> {
-        self.fields.iter().find(|x| x.key() == key)
-    }
 }
 
 impl AstNode for CardanoPublishBlockField {
@@ -707,25 +689,25 @@ impl Analyzable for CardanoPublishBlock {
 impl IntoLower for CardanoPublishBlockField {
     type Output = (String, ir::Expression);
 
-    fn into_lower(
+    fn lower(
         &self,
         ctx: &crate::lowering::Context,
     ) -> Result<Self::Output, crate::lowering::Error> {
         match self {
             CardanoPublishBlockField::To(x) => {
                 let ctx = ctx.enter_address_expr();
-                Ok(("to".to_string(), x.into_lower(&ctx)?))
+                Ok(("to".to_string(), x.lower(&ctx)?))
             }
             CardanoPublishBlockField::Amount(x) => {
                 let ctx = ctx.enter_asset_expr();
-                Ok(("amount".to_string(), x.into_lower(&ctx)?))
+                Ok(("amount".to_string(), x.lower(&ctx)?))
             }
             CardanoPublishBlockField::Datum(x) => {
                 let ctx = ctx.enter_datum_expr();
-                Ok(("datum".to_string(), x.into_lower(&ctx)?))
+                Ok(("datum".to_string(), x.lower(&ctx)?))
             }
-            CardanoPublishBlockField::Version(x) => Ok(("version".to_string(), x.into_lower(ctx)?)),
-            CardanoPublishBlockField::Script(x) => Ok(("script".to_string(), x.into_lower(ctx)?)),
+            CardanoPublishBlockField::Version(x) => Ok(("version".to_string(), x.lower(ctx)?)),
+            CardanoPublishBlockField::Script(x) => Ok(("script".to_string(), x.lower(ctx)?)),
         }
     }
 }
@@ -733,14 +715,14 @@ impl IntoLower for CardanoPublishBlockField {
 impl IntoLower for CardanoPublishBlock {
     type Output = ir::AdHocDirective;
 
-    fn into_lower(
+    fn lower(
         &self,
         ctx: &crate::lowering::Context,
     ) -> Result<Self::Output, crate::lowering::Error> {
         let data = self
             .fields
             .iter()
-            .map(|x| x.into_lower(ctx))
+            .map(|x| x.lower(ctx))
             .collect::<Result<_, _>>()?;
 
         Ok(ir::AdHocDirective {
@@ -836,18 +818,18 @@ impl Analyzable for CardanoBlock {
 impl IntoLower for CardanoBlock {
     type Output = ir::AdHocDirective;
 
-    fn into_lower(
+    fn lower(
         &self,
         ctx: &crate::lowering::Context,
     ) -> Result<<CardanoBlock as IntoLower>::Output, crate::lowering::Error> {
         match self {
-            CardanoBlock::VoteDelegationCertificate(x) => x.into_lower(ctx),
-            CardanoBlock::StakeDelegationCertificate(x) => x.into_lower(ctx),
-            CardanoBlock::Withdrawal(x) => x.into_lower(ctx),
-            CardanoBlock::PlutusWitness(x) => x.into_lower(ctx),
-            CardanoBlock::NativeWitness(x) => x.into_lower(ctx),
-            CardanoBlock::TreasuryDonation(x) => x.into_lower(ctx),
-            CardanoBlock::Publish(x) => x.into_lower(ctx),
+            CardanoBlock::VoteDelegationCertificate(x) => x.lower(ctx),
+            CardanoBlock::StakeDelegationCertificate(x) => x.lower(ctx),
+            CardanoBlock::Withdrawal(x) => x.lower(ctx),
+            CardanoBlock::PlutusWitness(x) => x.lower(ctx),
+            CardanoBlock::NativeWitness(x) => x.lower(ctx),
+            CardanoBlock::TreasuryDonation(x) => x.lower(ctx),
+            CardanoBlock::Publish(x) => x.lower(ctx),
         }
     }
 }

--- a/crates/tx3-lang/src/facade.rs
+++ b/crates/tx3-lang/src/facade.rs
@@ -159,7 +159,7 @@ pub mod tests {
         let manifest_dir = env!("CARGO_MANIFEST_DIR");
 
         let mut workspace =
-            Workspace::from_file(&format!("{manifest_dir}/../..//examples/transfer.tx3")).unwrap();
+            Workspace::from_file(format!("{manifest_dir}/../..//examples/transfer.tx3")).unwrap();
 
         workspace.parse().unwrap();
         workspace.analyze().unwrap();

--- a/crates/tx3-lang/src/lib.rs
+++ b/crates/tx3-lang/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code, clippy::wrong_self_convention)]
-
 //! The Tx3 language
 //!
 //! This crate provides the parser, analyzer and lowering logic for the Tx3

--- a/crates/tx3-lang/src/lib.rs
+++ b/crates/tx3-lang/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, clippy::wrong_self_convention)]
+
 //! The Tx3 language
 //!
 //! This crate provides the parser, analyzer and lowering logic for the Tx3

--- a/crates/tx3-lang/src/lowering.rs
+++ b/crates/tx3-lang/src/lowering.rs
@@ -188,7 +188,7 @@ impl Context {
 pub(crate) trait IntoLower {
     type Output;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error>;
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error>;
 }
 
 impl<T> IntoLower for Option<&T>
@@ -197,8 +197,8 @@ where
 {
     type Output = Option<T::Output>;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
-        self.map(|x| x.into_lower(ctx)).transpose()
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+        self.map(|x| x.lower(ctx)).transpose()
     }
 }
 
@@ -208,15 +208,15 @@ where
 {
     type Output = T::Output;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
-        self.as_ref().into_lower(ctx)
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+        self.as_ref().lower(ctx)
     }
 }
 
 impl IntoLower for ast::Identifier {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         let symbol = self
             .symbol
             .as_ref()
@@ -224,16 +224,16 @@ impl IntoLower for ast::Identifier {
 
         match symbol {
             ast::Symbol::ParamVar(n, ty) => {
-                Ok(ir::Param::ExpectValue(n.to_lowercase().clone(), ty.into_lower(ctx)?).into())
+                Ok(ir::Param::ExpectValue(n.to_lowercase().clone(), ty.lower(ctx)?).into())
             }
-            ast::Symbol::LocalExpr(expr) => Ok(expr.into_lower(ctx)?),
+            ast::Symbol::LocalExpr(expr) => Ok(expr.lower(ctx)?),
             ast::Symbol::PartyDef(x) => Ok(ir::Param::ExpectValue(
                 x.name.value.to_lowercase().clone(),
                 Type::Address,
             )
             .into()),
             ast::Symbol::Input(def) => {
-                let inner = def.into_lower(ctx)?.utxos;
+                let inner = def.lower(ctx)?.utxos;
 
                 let out = if ctx.is_asset_expr() {
                     ir::Coerce::IntoAssets(inner).into()
@@ -245,13 +245,13 @@ impl IntoLower for ast::Identifier {
 
                 Ok(out)
             }
-            ast::Symbol::Reference(def) => def.into_lower(ctx),
+            ast::Symbol::Reference(def) => def.lower(ctx),
             ast::Symbol::Fees => Ok(ir::Param::ExpectFees.into()),
             ast::Symbol::EnvVar(n, ty) => {
-                Ok(ir::Param::ExpectValue(n.to_lowercase().clone(), ty.into_lower(ctx)?).into())
+                Ok(ir::Param::ExpectValue(n.to_lowercase().clone(), ty.lower(ctx)?).into())
             }
             ast::Symbol::PolicyDef(x) => {
-                let policy = x.into_lower(ctx)?;
+                let policy = x.lower(ctx)?;
 
                 // Capture the ref UTxO only where the script runs, not in every
                 // address position (an output `to` receives funds without
@@ -280,7 +280,7 @@ impl IntoLower for ast::Identifier {
 impl IntoLower for ast::UtxoRef {
     type Output = ir::Expression;
 
-    fn into_lower(&self, _: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, _: &Context) -> Result<Self::Output, Error> {
         let x = ir::Expression::UtxoRefs(vec![UtxoRef {
             txid: self.txid.clone(),
             index: self.index as u32,
@@ -293,7 +293,7 @@ impl IntoLower for ast::UtxoRef {
 impl IntoLower for ast::StructConstructor {
     type Output = ir::StructExpr;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         let type_def = expect_type_def(&self.r#type)
             .or_else(|_| {
                 expect_alias_def(&self.r#type).and_then(|alias_def| {
@@ -316,14 +316,14 @@ impl IntoLower for ast::StructConstructor {
             let value = self.case.find_field_value(&field_def.name.value);
 
             if let Some(value) = value {
-                fields.push(value.into_lower(ctx)?);
+                fields.push(value.lower(ctx)?);
             } else {
                 let spread_target = self
                     .case
                     .spread
                     .as_ref()
                     .expect("spread must be set for missing explicit field")
-                    .into_lower(ctx)?;
+                    .lower(ctx)?;
 
                 fields.push(ir::Expression::EvalBuiltIn(Box::new(
                     ir::BuiltInOp::Property(spread_target, ir::Expression::Number(index as i128)),
@@ -341,11 +341,11 @@ impl IntoLower for ast::StructConstructor {
 impl IntoLower for ast::PolicyField {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         match self {
-            ast::PolicyField::Hash(x) => x.into_lower(ctx),
-            ast::PolicyField::Script(x) => x.into_lower(ctx),
-            ast::PolicyField::Ref(x) => x.into_lower(ctx),
+            ast::PolicyField::Hash(x) => x.lower(ctx),
+            ast::PolicyField::Script(x) => x.lower(ctx),
+            ast::PolicyField::Ref(x) => x.lower(ctx),
         }
     }
 }
@@ -353,7 +353,7 @@ impl IntoLower for ast::PolicyField {
 impl IntoLower for ast::PolicyDef {
     type Output = ir::PolicyExpr;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         match &self.value {
             ast::PolicyValue::Assign(x) => {
                 let out = ir::PolicyExpr {
@@ -368,14 +368,11 @@ impl IntoLower for ast::PolicyDef {
                 let hash = x
                     .find_field("hash")
                     .ok_or(Error::InvalidAst("Missing policy hash".to_string()))?
-                    .into_lower(ctx)?;
+                    .lower(ctx)?;
 
-                let rf = x.find_field("ref").map(|x| x.into_lower(ctx)).transpose()?;
+                let rf = x.find_field("ref").map(|x| x.lower(ctx)).transpose()?;
 
-                let script = x
-                    .find_field("script")
-                    .map(|x| x.into_lower(ctx))
-                    .transpose()?;
+                let script = x.find_field("script").map(|x| x.lower(ctx)).transpose()?;
 
                 let script = match (rf, script) {
                     (Some(rf), Some(script)) => ir::ScriptSource::new_ref(rf, script),
@@ -399,7 +396,7 @@ impl IntoLower for ast::PolicyDef {
 impl IntoLower for ast::Type {
     type Output = Type;
 
-    fn into_lower(&self, _: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, _: &Context) -> Result<Self::Output, Error> {
         match self {
             ast::Type::Undefined => Ok(Type::Undefined),
             ast::Type::Unit => Ok(Type::Unit),
@@ -421,9 +418,9 @@ impl IntoLower for ast::Type {
 impl IntoLower for ast::AddOp {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
-        let left = self.lhs.into_lower(ctx)?;
-        let right = self.rhs.into_lower(ctx)?;
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+        let left = self.lhs.lower(ctx)?;
+        let right = self.rhs.lower(ctx)?;
 
         Ok(ir::Expression::EvalBuiltIn(Box::new(ir::BuiltInOp::Add(
             left, right,
@@ -434,9 +431,9 @@ impl IntoLower for ast::AddOp {
 impl IntoLower for ast::SubOp {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
-        let left = self.lhs.into_lower(ctx)?;
-        let right = self.rhs.into_lower(ctx)?;
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+        let left = self.lhs.lower(ctx)?;
+        let right = self.rhs.lower(ctx)?;
 
         Ok(ir::Expression::EvalBuiltIn(Box::new(ir::BuiltInOp::Sub(
             left, right,
@@ -447,9 +444,9 @@ impl IntoLower for ast::SubOp {
 impl IntoLower for ast::MulOp {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
-        let left = self.lhs.into_lower(ctx)?;
-        let right = self.rhs.into_lower(ctx)?;
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+        let left = self.lhs.lower(ctx)?;
+        let right = self.rhs.lower(ctx)?;
 
         Ok(ir::Expression::EvalBuiltIn(Box::new(ir::BuiltInOp::Mul(
             left, right,
@@ -460,9 +457,9 @@ impl IntoLower for ast::MulOp {
 impl IntoLower for ast::DivOp {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
-        let left = self.lhs.into_lower(ctx)?;
-        let right = self.rhs.into_lower(ctx)?;
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+        let left = self.lhs.lower(ctx)?;
+        let right = self.rhs.lower(ctx)?;
 
         Ok(ir::Expression::EvalBuiltIn(Box::new(ir::BuiltInOp::Div(
             left, right,
@@ -473,9 +470,9 @@ impl IntoLower for ast::DivOp {
 impl IntoLower for ast::ConcatOp {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
-        let left = self.lhs.into_lower(ctx)?;
-        let right = self.rhs.into_lower(ctx)?;
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+        let left = self.lhs.lower(ctx)?;
+        let right = self.rhs.lower(ctx)?;
 
         Ok(ir::Expression::EvalBuiltIn(Box::new(
             ir::BuiltInOp::Concat(left, right),
@@ -486,8 +483,8 @@ impl IntoLower for ast::ConcatOp {
 impl IntoLower for ast::NegateOp {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
-        let operand = self.operand.into_lower(ctx)?;
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+        let operand = self.operand.lower(ctx)?;
 
         Ok(ir::Expression::EvalBuiltIn(Box::new(
             ir::BuiltInOp::Negate(operand),
@@ -498,7 +495,7 @@ impl IntoLower for ast::NegateOp {
 impl IntoLower for ast::FnCall {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         // A callee that resolves to a function definition is either a built-in
         // (lowered to a dedicated compiler op) or a user-defined function
         // (inlined below).
@@ -516,11 +513,11 @@ impl IntoLower for ast::FnCall {
                 ))
             })?;
 
-            let lowered_body = body.result.into_lower(ctx)?;
+            let lowered_body = body.result.lower(ctx)?;
 
             let mut subs = std::collections::HashMap::new();
             for (param, arg) in fn_def.parameters.parameters.iter().zip(&self.args) {
-                subs.insert(param.name.value.to_lowercase(), arg.into_lower(ctx)?);
+                subs.insert(param.name.value.to_lowercase(), arg.lower(ctx)?);
             }
 
             use tx3_tir::Node;
@@ -534,9 +531,9 @@ impl IntoLower for ast::FnCall {
         // constructor.
         match coerce_identifier_into_asset_def(&self.callee) {
             Ok(asset_def) => {
-                let policy = asset_def.policy.into_lower(ctx)?;
-                let asset_name = asset_def.asset_name.into_lower(ctx)?;
-                let amount = self.args[0].into_lower(ctx)?;
+                let policy = asset_def.policy.lower(ctx)?;
+                let asset_name = asset_def.asset_name.lower(ctx)?;
+                let amount = self.args[0].lower(ctx)?;
 
                 Ok(ir::Expression::Assets(vec![ir::AssetExpr {
                     policy,
@@ -574,8 +571,8 @@ impl tx3_tir::Visitor for ParamSubstituter<'_> {
 impl IntoLower for ast::PropertyOp {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
-        let object = self.operand.into_lower(ctx)?;
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+        let object = self.operand.lower(ctx)?;
 
         let ty = self
             .operand
@@ -590,7 +587,7 @@ impl IntoLower for ast::PropertyOp {
                 ))?;
 
         Ok(ir::Expression::EvalBuiltIn(Box::new(
-            ir::BuiltInOp::Property(object, prop_index.into_lower(ctx)?),
+            ir::BuiltInOp::Property(object, prop_index.lower(ctx)?),
         )))
     }
 }
@@ -598,11 +595,11 @@ impl IntoLower for ast::PropertyOp {
 impl IntoLower for ast::ListConstructor {
     type Output = Vec<ir::Expression>;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         let elements = self
             .elements
             .iter()
-            .map(|x| x.into_lower(ctx))
+            .map(|x| x.lower(ctx))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(elements)
@@ -612,11 +609,11 @@ impl IntoLower for ast::ListConstructor {
 impl IntoLower for ast::TupleConstructor {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         let elements = self
             .elements
             .iter()
-            .map(|x| x.into_lower(ctx))
+            .map(|x| x.lower(ctx))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(ir::Expression::Tuple(elements))
@@ -626,13 +623,13 @@ impl IntoLower for ast::TupleConstructor {
 impl IntoLower for ast::MapConstructor {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         let pairs = self
             .fields
             .iter()
             .map(|field| {
-                let key = field.key.into_lower(ctx)?;
-                let value = field.value.into_lower(ctx)?;
+                let key = field.key.lower(ctx)?;
+                let value = field.value.lower(ctx)?;
                 Ok((key, value))
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -644,29 +641,29 @@ impl IntoLower for ast::MapConstructor {
 impl IntoLower for ast::DataExpr {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         let out = match self {
             ast::DataExpr::None => ir::Expression::None,
             ast::DataExpr::Number(x) => Self::Output::Number(*x as i128),
             ast::DataExpr::Bool(x) => ir::Expression::Bool(*x),
             ast::DataExpr::String(x) => ir::Expression::String(x.value.clone()),
             ast::DataExpr::HexString(x) => ir::Expression::Bytes(hex_decode(&x.value)?),
-            ast::DataExpr::StructConstructor(x) => ir::Expression::Struct(x.into_lower(ctx)?),
-            ast::DataExpr::ListConstructor(x) => ir::Expression::List(x.into_lower(ctx)?),
-            ast::DataExpr::MapConstructor(x) => x.into_lower(ctx)?,
-            ast::DataExpr::TupleConstructor(x) => x.into_lower(ctx)?,
-            ast::DataExpr::AnyAssetConstructor(x) => x.into_lower(ctx)?,
+            ast::DataExpr::StructConstructor(x) => ir::Expression::Struct(x.lower(ctx)?),
+            ast::DataExpr::ListConstructor(x) => ir::Expression::List(x.lower(ctx)?),
+            ast::DataExpr::MapConstructor(x) => x.lower(ctx)?,
+            ast::DataExpr::TupleConstructor(x) => x.lower(ctx)?,
+            ast::DataExpr::AnyAssetConstructor(x) => x.lower(ctx)?,
             ast::DataExpr::Unit => ir::Expression::Struct(ir::StructExpr::unit()),
-            ast::DataExpr::Identifier(x) => x.into_lower(ctx)?,
-            ast::DataExpr::AddOp(x) => x.into_lower(ctx)?,
-            ast::DataExpr::SubOp(x) => x.into_lower(ctx)?,
-            ast::DataExpr::MulOp(x) => x.into_lower(ctx)?,
-            ast::DataExpr::DivOp(x) => x.into_lower(ctx)?,
-            ast::DataExpr::ConcatOp(x) => x.into_lower(ctx)?,
-            ast::DataExpr::NegateOp(x) => x.into_lower(ctx)?,
-            ast::DataExpr::PropertyOp(x) => x.into_lower(ctx)?,
-            ast::DataExpr::UtxoRef(x) => x.into_lower(ctx)?,
-            ast::DataExpr::FnCall(x) => x.into_lower(ctx)?,
+            ast::DataExpr::Identifier(x) => x.lower(ctx)?,
+            ast::DataExpr::AddOp(x) => x.lower(ctx)?,
+            ast::DataExpr::SubOp(x) => x.lower(ctx)?,
+            ast::DataExpr::MulOp(x) => x.lower(ctx)?,
+            ast::DataExpr::DivOp(x) => x.lower(ctx)?,
+            ast::DataExpr::ConcatOp(x) => x.lower(ctx)?,
+            ast::DataExpr::NegateOp(x) => x.lower(ctx)?,
+            ast::DataExpr::PropertyOp(x) => x.lower(ctx)?,
+            ast::DataExpr::UtxoRef(x) => x.lower(ctx)?,
+            ast::DataExpr::FnCall(x) => x.lower(ctx)?,
         };
 
         Ok(out)
@@ -676,15 +673,15 @@ impl IntoLower for ast::DataExpr {
 impl IntoLower for ast::AnyAssetConstructor {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         let ctx = &ctx.enter_datum_expr();
-        let policy = self.policy.into_lower(ctx)?;
+        let policy = self.policy.lower(ctx)?;
 
         let ctx = &ctx.enter_datum_expr();
-        let asset_name = self.asset_name.into_lower(ctx)?;
+        let asset_name = self.asset_name.lower(ctx)?;
 
         let ctx = &ctx.enter_datum_expr();
-        let amount = self.amount.into_lower(ctx)?;
+        let amount = self.amount.lower(ctx)?;
 
         Ok(ir::Expression::Assets(vec![ir::AssetExpr {
             policy,
@@ -697,23 +694,23 @@ impl IntoLower for ast::AnyAssetConstructor {
 impl IntoLower for ast::InputBlockField {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         match self {
             ast::InputBlockField::From(x) => {
                 // Spending from a script address runs its script.
                 let ctx = ctx.enter_address_expr().capturing_policy_refs();
-                x.into_lower(&ctx)
+                x.lower(&ctx)
             }
             ast::InputBlockField::DatumIs(_) => todo!(),
             ast::InputBlockField::MinAmount(x) => {
                 let ctx = ctx.enter_asset_expr();
-                x.into_lower(&ctx)
+                x.lower(&ctx)
             }
             ast::InputBlockField::Redeemer(x) => {
                 let ctx = ctx.enter_datum_expr();
-                x.into_lower(&ctx)
+                x.lower(&ctx)
             }
-            ast::InputBlockField::Ref(x) => x.into_lower(ctx),
+            ast::InputBlockField::Ref(x) => x.lower(ctx),
         }
     }
 }
@@ -721,21 +718,18 @@ impl IntoLower for ast::InputBlockField {
 impl IntoLower for ast::InputBlock {
     type Output = ir::Input;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         let from_field = self.find("from");
 
-        let address = from_field.map(|x| x.into_lower(ctx)).transpose()?;
+        let address = from_field.map(|x| x.lower(ctx)).transpose()?;
 
-        let min_amount = self
-            .find("min_amount")
-            .map(|x| x.into_lower(ctx))
-            .transpose()?;
+        let min_amount = self.find("min_amount").map(|x| x.lower(ctx)).transpose()?;
 
-        let r#ref = self.find("ref").map(|x| x.into_lower(ctx)).transpose()?;
+        let r#ref = self.find("ref").map(|x| x.lower(ctx)).transpose()?;
 
         let redeemer = self
             .find("redeemer")
-            .map(|x| x.into_lower(ctx))
+            .map(|x| x.lower(ctx))
             .transpose()?
             .unwrap_or(ir::Expression::None);
 
@@ -762,19 +756,19 @@ impl IntoLower for ast::InputBlock {
 impl IntoLower for ast::OutputBlockField {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         match self {
             ast::OutputBlockField::To(x) => {
                 let ctx = ctx.enter_address_expr();
-                x.into_lower(&ctx)
+                x.lower(&ctx)
             }
             ast::OutputBlockField::Amount(x) => {
                 let ctx = ctx.enter_asset_expr();
-                x.into_lower(&ctx)
+                x.lower(&ctx)
             }
             ast::OutputBlockField::Datum(x) => {
                 let ctx = ctx.enter_datum_expr();
-                x.into_lower(&ctx)
+                x.lower(&ctx)
             }
         }
     }
@@ -783,10 +777,10 @@ impl IntoLower for ast::OutputBlockField {
 impl IntoLower for ast::OutputBlock {
     type Output = ir::Output;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
-        let address = self.find("to").into_lower(ctx)?.unwrap_or_default();
-        let datum = self.find("datum").into_lower(ctx)?.unwrap_or_default();
-        let amount = self.find("amount").into_lower(ctx)?.unwrap_or_default();
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+        let address = self.find("to").lower(ctx)?.unwrap_or_default();
+        let datum = self.find("datum").lower(ctx)?.unwrap_or_default();
+        let amount = self.find("amount").lower(ctx)?.unwrap_or_default();
 
         Ok(ir::Output {
             address,
@@ -800,10 +794,10 @@ impl IntoLower for ast::OutputBlock {
 impl IntoLower for ast::ValidityBlockField {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         match self {
-            ast::ValidityBlockField::SinceSlot(x) => x.into_lower(ctx),
-            ast::ValidityBlockField::UntilSlot(x) => x.into_lower(ctx),
+            ast::ValidityBlockField::SinceSlot(x) => x.lower(ctx),
+            ast::ValidityBlockField::UntilSlot(x) => x.lower(ctx),
         }
     }
 }
@@ -811,9 +805,9 @@ impl IntoLower for ast::ValidityBlockField {
 impl IntoLower for ast::ValidityBlock {
     type Output = ir::Validity;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
-        let since = self.find("since_slot").into_lower(ctx)?.unwrap_or_default();
-        let until = self.find("until_slot").into_lower(ctx)?.unwrap_or_default();
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+        let since = self.find("since_slot").lower(ctx)?.unwrap_or_default();
+        let until = self.find("until_slot").lower(ctx)?.unwrap_or_default();
 
         Ok(ir::Validity { since, until })
     }
@@ -822,11 +816,11 @@ impl IntoLower for ast::ValidityBlock {
 impl IntoLower for ast::MintBlockField {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         match self {
             // Minting/burning runs the asset's policy script.
-            ast::MintBlockField::Amount(x) => x.into_lower(&ctx.capturing_policy_refs()),
-            ast::MintBlockField::Redeemer(x) => x.into_lower(ctx),
+            ast::MintBlockField::Amount(x) => x.lower(&ctx.capturing_policy_refs()),
+            ast::MintBlockField::Redeemer(x) => x.lower(ctx),
         }
     }
 }
@@ -834,9 +828,9 @@ impl IntoLower for ast::MintBlockField {
 impl IntoLower for ast::MintBlock {
     type Output = ir::Mint;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
-        let amount = self.find("amount").into_lower(ctx)?.unwrap_or_default();
-        let redeemer = self.find("redeemer").into_lower(ctx)?.unwrap_or_default();
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+        let amount = self.find("amount").lower(ctx)?.unwrap_or_default();
+        let redeemer = self.find("redeemer").lower(ctx)?.unwrap_or_default();
 
         Ok(ir::Mint { amount, redeemer })
     }
@@ -844,10 +838,10 @@ impl IntoLower for ast::MintBlock {
 
 impl IntoLower for ast::MetadataBlockField {
     type Output = ir::Metadata;
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         Ok(ir::Metadata {
-            key: self.key.into_lower(ctx)?,
-            value: self.value.into_lower(ctx)?,
+            key: self.key.lower(ctx)?,
+            value: self.value.lower(ctx)?,
         })
     }
 }
@@ -855,11 +849,11 @@ impl IntoLower for ast::MetadataBlockField {
 impl IntoLower for ast::MetadataBlock {
     type Output = Vec<ir::Metadata>;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         let fields = self
             .fields
             .iter()
-            .map(|metadata_field| metadata_field.into_lower(ctx))
+            .map(|metadata_field| metadata_field.lower(ctx))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(fields)
@@ -869,9 +863,9 @@ impl IntoLower for ast::MetadataBlock {
 impl IntoLower for ast::ChainSpecificBlock {
     type Output = ir::AdHocDirective;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         match self {
-            ast::ChainSpecificBlock::Cardano(x) => x.into_lower(ctx),
+            ast::ChainSpecificBlock::Cardano(x) => x.lower(ctx),
         }
     }
 }
@@ -879,8 +873,8 @@ impl IntoLower for ast::ChainSpecificBlock {
 impl IntoLower for ast::ReferenceBlock {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
-        let r#ref = self.r#ref.into_lower(ctx)?;
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+        let r#ref = self.r#ref.lower(ctx)?;
 
         let query = ir::InputQuery {
             address: ir::Expression::None,
@@ -907,11 +901,11 @@ impl IntoLower for ast::ReferenceBlock {
 impl IntoLower for ast::CollateralBlockField {
     type Output = ir::Expression;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         match self {
-            ast::CollateralBlockField::From(x) => x.into_lower(ctx),
-            ast::CollateralBlockField::MinAmount(x) => x.into_lower(ctx),
-            ast::CollateralBlockField::Ref(x) => x.into_lower(ctx),
+            ast::CollateralBlockField::From(x) => x.lower(ctx),
+            ast::CollateralBlockField::MinAmount(x) => x.lower(ctx),
+            ast::CollateralBlockField::Ref(x) => x.lower(ctx),
         }
     }
 }
@@ -919,15 +913,12 @@ impl IntoLower for ast::CollateralBlockField {
 impl IntoLower for ast::CollateralBlock {
     type Output = ir::Collateral;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
-        let from = self.find("from").map(|x| x.into_lower(ctx)).transpose()?;
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+        let from = self.find("from").map(|x| x.lower(ctx)).transpose()?;
 
-        let min_amount = self
-            .find("min_amount")
-            .map(|x| x.into_lower(ctx))
-            .transpose()?;
+        let min_amount = self.find("min_amount").map(|x| x.lower(ctx)).transpose()?;
 
-        let r#ref = self.find("ref").map(|x| x.into_lower(ctx)).transpose()?;
+        let r#ref = self.find("ref").map(|x| x.lower(ctx)).transpose()?;
 
         let query = ir::InputQuery {
             address: from.unwrap_or(ir::Expression::None),
@@ -950,12 +941,12 @@ impl IntoLower for ast::CollateralBlock {
 impl IntoLower for ast::SignersBlock {
     type Output = ir::Signers;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         Ok(ir::Signers {
             signers: self
                 .signers
                 .iter()
-                .map(|x| x.into_lower(ctx))
+                .map(|x| x.lower(ctx))
                 .collect::<Result<Vec<_>, _>>()?,
         })
     }
@@ -964,58 +955,50 @@ impl IntoLower for ast::SignersBlock {
 impl IntoLower for ast::TxDef {
     type Output = ir::Tx;
 
-    fn into_lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
+    fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
         // Seed with explicit `reference` blocks first so they dedup against,
         // and precede, refs that the body derives from ref-backed policies.
         for reference in self.references.iter() {
-            let r#ref = reference.r#ref.into_lower(ctx)?;
+            let r#ref = reference.r#ref.lower(ctx)?;
             ctx.record_script_ref(r#ref);
         }
 
         let inputs = self
             .inputs
             .iter()
-            .map(|x| x.into_lower(ctx))
+            .map(|x| x.lower(ctx))
             .collect::<Result<Vec<_>, _>>()?;
         let outputs = self
             .outputs
             .iter()
-            .map(|x| x.into_lower(ctx))
+            .map(|x| x.lower(ctx))
             .collect::<Result<Vec<_>, _>>()?;
-        let validity = self
-            .validity
-            .as_ref()
-            .map(|x| x.into_lower(ctx))
-            .transpose()?;
+        let validity = self.validity.as_ref().map(|x| x.lower(ctx)).transpose()?;
         let mints = self
             .mints
             .iter()
-            .map(|x| x.into_lower(ctx))
+            .map(|x| x.lower(ctx))
             .collect::<Result<Vec<_>, _>>()?;
         let burns = self
             .burns
             .iter()
-            .map(|x| x.into_lower(ctx))
+            .map(|x| x.lower(ctx))
             .collect::<Result<Vec<_>, _>>()?;
         let adhoc = self
             .adhoc
             .iter()
-            .map(|x| x.into_lower(ctx))
+            .map(|x| x.lower(ctx))
             .collect::<Result<Vec<_>, _>>()?;
         let collateral = self
             .collateral
             .iter()
-            .map(|x| x.into_lower(ctx))
+            .map(|x| x.lower(ctx))
             .collect::<Result<Vec<_>, _>>()?;
-        let signers = self
-            .signers
-            .as_ref()
-            .map(|x| x.into_lower(ctx))
-            .transpose()?;
+        let signers = self.signers.as_ref().map(|x| x.lower(ctx)).transpose()?;
         let metadata = self
             .metadata
             .as_ref()
-            .map(|x| x.into_lower(ctx))
+            .map(|x| x.lower(ctx))
             .transpose()?
             .unwrap_or(vec![]);
 
@@ -1040,7 +1023,7 @@ impl IntoLower for ast::TxDef {
 pub fn lower_tx(ast: &ast::TxDef) -> Result<ir::Tx, Error> {
     let ctx = &Context::default();
 
-    let tx = ast.into_lower(ctx)?;
+    let tx = ast.lower(ctx)?;
 
     Ok(tx)
 }

--- a/crates/tx3-lang/src/lowering.rs
+++ b/crates/tx3-lang/src/lowering.rs
@@ -559,10 +559,7 @@ struct ParamSubstituter<'a> {
 }
 
 impl tx3_tir::Visitor for ParamSubstituter<'_> {
-    fn reduce(
-        &mut self,
-        expr: ir::Expression,
-    ) -> Result<ir::Expression, tx3_tir::reduce::Error> {
+    fn reduce(&mut self, expr: ir::Expression) -> Result<ir::Expression, tx3_tir::reduce::Error> {
         if let ir::Expression::EvalParam(ref param) = expr {
             if let ir::Param::ExpectValue(name, _) = param.as_ref() {
                 if let Some(replacement) = self.subs.get(name) {

--- a/crates/tx3-lang/src/parsing.rs
+++ b/crates/tx3-lang/src/parsing.rs
@@ -1805,10 +1805,7 @@ mod tests {
         Type,
         "tuple_nested",
         "Tuple<Tuple<Int, Int>, Bytes>",
-        Type::Tuple(vec![
-            Type::Tuple(vec![Type::Int, Type::Int]),
-            Type::Bytes,
-        ])
+        Type::Tuple(vec![Type::Tuple(vec![Type::Int, Type::Int]), Type::Bytes,])
     );
 
     input_to_ast_check!(

--- a/crates/tx3-lang/src/parsing.rs
+++ b/crates/tx3-lang/src/parsing.rs
@@ -643,7 +643,7 @@ impl AstNode for OutputBlock {
 
         let optional = inner
             .peek()
-            .map_or(false, |first| first.as_rule() == Rule::output_optional);
+            .is_some_and(|first| first.as_rule() == Rule::output_optional);
 
         if optional {
             inner.next();

--- a/crates/tx3-resolver/src/dump.rs
+++ b/crates/tx3-resolver/src/dump.rs
@@ -73,7 +73,7 @@ impl DiagnosticDump for Utxo {
 impl DiagnosticDump for CanonicalQuery {
     fn to_dump(&self) -> Value {
         json!({
-            "address": self.address.as_ref().map(|a| hex::encode(a)),
+            "address": self.address.as_ref().map(hex::encode),
             "min_amount": self.min_amount.as_ref().map(|a| a.to_dump()),
             "refs": self.refs.iter().map(|r| r.to_dump()).collect::<Vec<_>>(),
             "support_many": self.support_many,
@@ -164,8 +164,7 @@ pub fn dump_to_dir(job: &ResolveJob, dir: &Path) -> Result<String, std::io::Erro
     let dump_id = uuid::Uuid::new_v4().to_string();
     let path = dir.join(format!("resolve-job-{dump_id}.json"));
     let file = std::fs::File::create(&path)?;
-    serde_json::to_writer_pretty(file, &job.to_dump())
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    serde_json::to_writer_pretty(file, &job.to_dump()).map_err(std::io::Error::other)?;
     tracing::debug!(dump_id = %dump_id, path = %path.display(), "diagnostic dump written");
     Ok(dump_id)
 }

--- a/crates/tx3-resolver/src/inputs/approximate/filter.rs
+++ b/crates/tx3-resolver/src/inputs/approximate/filter.rs
@@ -16,7 +16,7 @@ fn matches_address_constraint(query: &CanonicalQuery, utxo: &Utxo) -> bool {
     query
         .address
         .as_ref()
-        .map_or(true, |addr| utxo.address == *addr)
+        .is_none_or(|addr| utxo.address == *addr)
 }
 
 fn matches_ref_constraint(query: &CanonicalQuery, utxo: &Utxo) -> bool {

--- a/crates/tx3-resolver/src/inputs/approximate/rank/mod.rs
+++ b/crates/tx3-resolver/src/inputs/approximate/rank/mod.rs
@@ -9,6 +9,7 @@ use tx3_tir::model::{
 };
 
 pub mod naive;
+#[cfg(not(feature = "naive_selector"))]
 pub mod vector;
 
 /// Rank candidates by relevance to a target asset composition.

--- a/crates/tx3-resolver/src/inputs/approximate/rank/vector.rs
+++ b/crates/tx3-resolver/src/inputs/approximate/rank/vector.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use std::collections::HashSet;
 use tx3_tir::model::{
     assets::{AssetClass, CanonicalAssets},
@@ -192,7 +193,7 @@ mod tests {
                 let expected = f64::hypot(delta_x, delta_y).round() as u32;
                 approx::assert_abs_diff_eq!(distance, expected, epsilon = 1);
             } else {
-                let expected = (vec_a[0] as i64 - vec_b[0] as i64).abs() as u32;
+                let expected = (vec_a[0] as i64 - vec_b[0] as i64).unsigned_abs() as u32;
                 approx::assert_abs_diff_eq!(distance, expected, epsilon = 1);
             }
         }

--- a/crates/tx3-resolver/src/inputs/approximate/rank/vector.rs
+++ b/crates/tx3-resolver/src/inputs/approximate/rank/vector.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use std::collections::HashSet;
 use tx3_tir::model::{
     assets::{AssetClass, CanonicalAssets},

--- a/crates/tx3-resolver/src/inputs/narrow.rs
+++ b/crates/tx3-resolver/src/inputs/narrow.rs
@@ -250,11 +250,7 @@ mod tests {
     use crate::test_utils as mock;
 
     fn assets_for(asset: mock::KnownAsset, amount: i128) -> CanonicalAssets {
-        CanonicalAssets::from_asset(
-            Some(asset.policy().as_ref()),
-            Some(asset.name().as_ref()),
-            amount,
-        )
+        CanonicalAssets::from_asset(Some(asset.policy().as_ref()), Some(asset.name()), amount)
     }
 
     fn cq(
@@ -274,7 +270,7 @@ mod tests {
     fn prepare_store() -> mock::MockStore {
         mock::seed_random_memory_store(
             |_: &mock::FuzzTxoRef, x: &mock::KnownAddress, seq: u64| {
-                if seq % 2 == 0 {
+                if seq.is_multiple_of(2) {
                     mock::utxo_with_random_asset(x, mock::KnownAsset::Hosky, 500..1000)
                 } else {
                     mock::utxo_with_random_amount(x, 4_000_000..5_000_000)

--- a/crates/tx3-resolver/src/inputs/tests.rs
+++ b/crates/tx3-resolver/src/inputs/tests.rs
@@ -107,7 +107,7 @@ async fn test_input_query_too_broad() {
 async fn test_resolve_anything() {
     let store = mock::seed_random_memory_store(
         |_: &mock::FuzzTxoRef, x: &mock::KnownAddress, seq: u64| {
-            if seq % 2 == 0 {
+            if seq.is_multiple_of(2) {
                 mock::utxo_with_random_amount(x, 4_000_000..5_000_000)
             } else {
                 mock::utxo_with_random_asset(x, mock::KnownAsset::Hosky, 500..1000)
@@ -219,7 +219,7 @@ async fn test_resolve_by_asset_amount() {
 async fn test_resolve_by_collateral() {
     let store = mock::seed_random_memory_store(
         |_: &mock::FuzzTxoRef, x: &mock::KnownAddress, sequence: u64| {
-            if sequence % 2 == 0 {
+            if sequence.is_multiple_of(2) {
                 mock::utxo_with_random_amount(x, 4_000_000..5_000_000)
             } else {
                 mock::utxo_with_random_asset(x, mock::KnownAsset::Hosky, 500..1000)
@@ -266,7 +266,7 @@ async fn test_resolve_same_collateral_and_input() {
 async fn test_resolve_exclusive_assignments() {
     let store = mock::seed_random_memory_store(
         |_: &mock::FuzzTxoRef, x: &mock::KnownAddress, seq: u64| {
-            if seq % 2 == 0 {
+            if seq.is_multiple_of(2) {
                 mock::utxo_with_random_amount(x, 1_000..1_500)
             } else {
                 mock::utxo_with_random_amount(x, 100..150)
@@ -299,7 +299,7 @@ async fn test_resolve_exclusive_assignments() {
 async fn test_resolve_competing_queries() {
     let store = mock::seed_random_memory_store(
         |_: &mock::FuzzTxoRef, x: &mock::KnownAddress, seq: u64| {
-            if seq % 2 == 0 {
+            if seq.is_multiple_of(2) {
                 UtxoBuilder::new()
                     .with_address(x)
                     .with_naked_value(4_000_000)
@@ -342,7 +342,7 @@ async fn test_resolve_competing_queries() {
 
     let target_asset = CanonicalAssets::from_asset(
         Some(mock::KnownAsset::Hosky.policy().as_ref()),
-        Some(mock::KnownAsset::Hosky.name().as_ref()),
+        Some(mock::KnownAsset::Hosky.name()),
         1,
     );
     assert!(asset_utxos
@@ -392,7 +392,7 @@ async fn test_resolve_competing_queries_no_solution() {
 async fn test_resolve_by_naked_and_asset_amount() {
     let store = mock::seed_random_memory_store(
         |_: &mock::FuzzTxoRef, x: &mock::KnownAddress, sequence: u64| {
-            if sequence % 2 == 0 {
+            if sequence.is_multiple_of(2) {
                 mock::utxo_with_random_amount(x, 4_000_000..5_000_000)
             } else {
                 mock::utxo_with_random_asset(x, mock::KnownAsset::Hosky, 500..1000)
@@ -417,7 +417,7 @@ async fn test_resolve_by_naked_and_asset_amount() {
 async fn test_cross_query_pool_doesnt_leak_wrong_address() {
     let store = mock::seed_random_memory_store(
         |_: &mock::FuzzTxoRef, x: &mock::KnownAddress, seq: u64| {
-            if x.to_bytes() == mock::KnownAddress::Bob.to_bytes() && seq % 2 == 0 {
+            if x.to_bytes() == mock::KnownAddress::Bob.to_bytes() && seq.is_multiple_of(2) {
                 UtxoBuilder::new()
                     .with_address(x)
                     .with_naked_value(4_000_000)

--- a/crates/tx3-resolver/src/interop.rs
+++ b/crates/tx3-resolver/src/interop.rs
@@ -290,8 +290,16 @@ fn is_tagged(value: &Value) -> bool {
     matches!(
         single_key(value),
         Some((
-            "int" | "bool" | "string" | "bytes" | "address" | "utxoRef" | "list" | "tuple"
-                | "map" | "struct",
+            "int"
+                | "bool"
+                | "string"
+                | "bytes"
+                | "address"
+                | "utxoRef"
+                | "list"
+                | "tuple"
+                | "map"
+                | "struct",
             _,
         ))
     )
@@ -391,10 +399,10 @@ fn decode_struct(value: Value) -> Result<ArgValue, Error> {
         x => return Err(Error::MalformedStruct(x)),
     };
 
-    let constructor = obj
-        .get("constructor")
-        .and_then(Value::as_u64)
-        .ok_or_else(|| Error::MalformedStruct(Value::Object(obj.clone())))? as usize;
+    let constructor =
+        obj.get("constructor")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| Error::MalformedStruct(Value::Object(obj.clone())))? as usize;
 
     let fields = obj
         .remove("fields")
@@ -440,7 +448,9 @@ pub fn tagged_arg_to_json(arg: &ArgValue) -> Value {
         ArgValue::String(s) => serde_json::json!({ "string": s }),
         ArgValue::Bytes(v) => serde_json::json!({ "bytes": hex::encode(v) }),
         ArgValue::Address(v) => serde_json::json!({ "address": hex::encode(v) }),
-        ArgValue::UtxoRef(r) => serde_json::json!({ "utxoRef": format!("{}#{}", hex::encode(&r.txid), r.index) }),
+        ArgValue::UtxoRef(r) => {
+            serde_json::json!({ "utxoRef": format!("{}#{}", hex::encode(&r.txid), r.index) })
+        }
         // A resolved UTxO set is not a tagged leaf; surface it as null.
         ArgValue::UtxoSet(_) => Value::Null,
         ArgValue::List(xs) => {
@@ -759,7 +769,11 @@ mod tests {
     #[test]
     fn decode_accepts_tagged_scalar_leniently() {
         assert_from_json(json!({ "int": 5 }), Type::Int, ArgValue::Int(5));
-        assert_from_json(json!({ "bytes": "cafe" }), Type::Bytes, ArgValue::Bytes(vec![0xca, 0xfe]));
+        assert_from_json(
+            json!({ "bytes": "cafe" }),
+            Type::Bytes,
+            ArgValue::Bytes(vec![0xca, 0xfe]),
+        );
     }
 
     #[test]

--- a/crates/tx3-resolver/src/interop.rs
+++ b/crates/tx3-resolver/src/interop.rs
@@ -532,14 +532,14 @@ pub fn utxo_from_json(value: &Value) -> Result<Utxo, Error> {
         .filter(|v| !v.is_null())
         .map(|v| serde_json::from_value(v.clone()))
         .transpose()
-        .map_err(|e| Error::InvalidBytesEnvelope(e))?;
+        .map_err(Error::InvalidBytesEnvelope)?;
 
     let script = value
         .get("script")
         .filter(|v| !v.is_null())
         .map(|v| serde_json::from_value(v.clone()))
         .transpose()
-        .map_err(|e| Error::InvalidBytesEnvelope(e))?;
+        .map_err(Error::InvalidBytesEnvelope)?;
 
     Ok(Utxo {
         r#ref: utxo_ref,

--- a/crates/tx3-resolver/src/interop.rs
+++ b/crates/tx3-resolver/src/interop.rs
@@ -159,7 +159,8 @@ pub fn string_to_bigint(s: String) -> Result<i128, Error> {
             .map_err(|x| Error::InvalidBytesForNumber(hex::encode(x)))?;
         Ok(i128::from_be_bytes(bytes))
     } else {
-        let i = i128::from_str_radix(&s, 10)
+        let i = s
+            .parse::<i128>()
             .map_err(|x| Error::InvalidBytesForNumber(x.to_string()))?;
         Ok(i)
     }

--- a/crates/tx3-resolver/src/job.rs
+++ b/crates/tx3-resolver/src/job.rs
@@ -187,7 +187,7 @@ impl ResolveJob {
 
         let eval = compiler.compile(&attempt)?;
 
-        let converged = self.last_eval.as_ref().map_or(false, |prev| eval == *prev);
+        let converged = self.last_eval.as_ref().is_some_and(|prev| eval == *prev);
 
         self.record(ResolveLog::Compiled(eval.clone()));
         self.last_eval = Some(eval);

--- a/crates/tx3-resolver/src/job.rs
+++ b/crates/tx3-resolver/src/job.rs
@@ -11,7 +11,7 @@ use tx3_tir::reduce::{Apply as _, ArgMap};
 use tx3_tir::Node as _;
 
 use crate::inputs::CanonicalQuery;
-use crate::{Error, UtxoStore};
+use crate::{Error, InputNotResolvedError, UtxoStore};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ResolveLog {
@@ -68,11 +68,11 @@ impl QueryResolution {
     pub fn ensure_resolved(&self, pool_refs: &[UtxoRef]) -> Result<(), Error> {
         match &self.selection {
             Some(sel) if !sel.is_empty() => Ok(()),
-            _ => Err(Error::InputNotResolved(
-                self.name.clone(),
-                self.query.clone(),
-                pool_refs.to_vec(),
-            )),
+            _ => Err(Error::InputNotResolved(Box::new(InputNotResolvedError {
+                name: self.name.clone(),
+                query: self.query.clone(),
+                pool: pool_refs.to_vec(),
+            }))),
         }
     }
 }

--- a/crates/tx3-resolver/src/lib.rs
+++ b/crates/tx3-resolver/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, clippy::result_large_err, clippy::from_str_radix_10)]
+
 use std::collections::HashSet;
 
 use crate::inputs::CanonicalQuery;

--- a/crates/tx3-resolver/src/lib.rs
+++ b/crates/tx3-resolver/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code, clippy::result_large_err, clippy::from_str_radix_10)]
-
 use std::collections::HashSet;
 
 use crate::inputs::CanonicalQuery;
@@ -41,7 +39,7 @@ pub enum Error {
     InputQueryTooBroad,
 
     #[error("input not resolved: {0}")]
-    InputNotResolved(String, CanonicalQuery, Vec<UtxoRef>),
+    InputNotResolved(Box<InputNotResolvedError>),
 
     #[error("missing argument `{key}` of type {ty:?}")]
     MissingTxArg {
@@ -63,6 +61,19 @@ pub enum Error {
 
     #[error("tx script returned failure")]
     TxScriptFailure(Vec<String>),
+}
+
+#[derive(Debug)]
+pub struct InputNotResolvedError {
+    pub name: String,
+    pub query: CanonicalQuery,
+    pub pool: Vec<UtxoRef>,
+}
+
+impl std::fmt::Display for InputNotResolvedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
 }
 
 pub enum UtxoPattern<'a> {

--- a/crates/tx3-resolver/src/test_utils.rs
+++ b/crates/tx3-resolver/src/test_utils.rs
@@ -272,7 +272,7 @@ impl UtxoStore for MockStore {
     async fn narrow_refs(&self, pattern: UtxoPattern<'_>) -> Result<HashSet<UtxoRef>, Error> {
         match pattern {
             UtxoPattern::ByAddress(address) => {
-                let address = chainfuzz::Address::try_from(address).unwrap();
+                let address = chainfuzz::Address::from(address);
 
                 let narrow = self
                     .utxos
@@ -301,7 +301,7 @@ impl UtxoStore for MockStore {
             }
             UtxoPattern::ByAsset(policy, name) => {
                 let policy = chainfuzz::AssetPolicy::try_from(policy).unwrap();
-                let name = chainfuzz::AssetName::try_from(name).unwrap();
+                let name = chainfuzz::AssetName::from(name);
                 let asset_class = chainfuzz::AssetClass::new(policy, name);
 
                 let narrow = self
@@ -330,7 +330,7 @@ impl UtxoStore for MockStore {
                 chainfuzz::TxoRef::new(tx_hash, ordinal)
             })
             .map(|txo| (txo, self.utxos.get(&txo).unwrap()))
-            .map(|(txo, fuzz_utxo)| from_fuzz_utxo(&txo, &fuzz_utxo))
+            .map(|(txo, fuzz_utxo)| from_fuzz_utxo(&txo, fuzz_utxo))
             .collect::<Vec<_>>();
 
         Ok(utxos.into_iter().collect())
@@ -348,7 +348,7 @@ impl MockStore {
     pub async fn by_known_asset(&self, asset: &KnownAsset) -> HashSet<UtxoRef> {
         let policy = asset.policy();
         let name = asset.name();
-        let pattern = UtxoPattern::ByAsset(policy.as_ref(), name.as_ref());
+        let pattern = UtxoPattern::ByAsset(policy.as_ref(), name);
 
         self.narrow_refs(pattern).await.unwrap()
     }

--- a/crates/tx3-resolver/src/trp/errors.rs
+++ b/crates/tx3-resolver/src/trp/errors.rs
@@ -115,12 +115,12 @@ impl TrpError for crate::Error {
 
                 Some(json!(data))
             }
-            Error::InputNotResolved(name, q, pool) => {
+            Error::InputNotResolved(boxed) => {
                 let data = spec::InputNotResolvedDiagnostic {
-                    name: name.to_string(),
-                    query: q.clone().into_error_data(),
+                    name: boxed.name.to_string(),
+                    query: boxed.query.clone().into_error_data(),
                     search_space: spec::SearchSpaceDiagnostic {
-                        matched: pool.iter().map(ToString::to_string).collect(),
+                        matched: boxed.pool.iter().map(ToString::to_string).collect(),
                         by_address_count: None,
                         by_asset_class_count: None,
                         by_ref_count: None,

--- a/crates/tx3-resolver/src/trp/mod.rs
+++ b/crates/tx3-resolver/src/trp/mod.rs
@@ -15,7 +15,7 @@ pub fn parse_resolve_request(request: spec::ResolveParams) -> Result<(AnyTir, Ar
 
     for (key, val) in request.args {
         if let Some(ty) = params.get(&key) {
-            let arg = interop::from_json(val.clone(), &ty)?;
+            let arg = interop::from_json(val.clone(), ty)?;
             args.insert(key, arg);
         }
     }

--- a/release.toml
+++ b/release.toml
@@ -2,4 +2,4 @@ push = false
 publish = false
 tag-name = "v{{version}}"
 pre-release-commit-message = "release: v{{version}}"
-pre-release-hook = ["git", "cliff", "-o", "CHANGELOG.md", "--latest"]
+pre-release-hook = ["git", "cliff", "-o", "CHANGELOG.md", "--tag", "v{{version}}"]


### PR DESCRIPTION
Fixes formatting and clippy issues surfaced by the new CI workflow introduced in the previous hardening PR.

- Run `cargo fmt` to fix formatting
- Fix or allow pre-existing clippy warnings (`dead_code`, `unused_variables`, `result_large_err`, etc.) to unblock the `-D warnings` gate
- Address CodeRabbit review findings from the previous PR:
  - `permissions: contents: read` (least-privilege `GITHUB_TOKEN`)
  - `persist-credentials: false` on all checkout steps
  - `concurrency` group to cancel superseded CI runs
  - `--tag v{{version}}` instead of `--latest` in pre-release-hook