### PR TITLE
fix(lang): read reference datum fields in amount expressions

### DIFF
--- a/crates/tx3-lang/src/analyzing.rs
+++ b/crates/tx3-lang/src/analyzing.rs
@@ -440,9 +440,36 @@ impl Scope {
     }
 
     pub fn track_record_fields_for_type(&mut self, ty: &Type) {
-        let schema = ty.properties();
+        // `track_type_def` clones the def before field-type analysis resolves
+        // the original, so cloned/nested `Type::Custom` identifiers can carry a
+        // stale `None` symbol. Re-resolve against the scope so nested access
+        // (`ref.outer.inner`) tracks fields and yields a resolved type for
+        // lowering's `property_index`.
+        let resolved_ty = match ty {
+            Type::Custom(id) if id.symbol.is_none() => {
+                if let Some(symbol) = self.resolve(&id.value) {
+                    let mut resolved = ty.clone();
+                    if let Type::Custom(cloned_id) = &mut resolved {
+                        cloned_id.symbol = Some(symbol);
+                    }
+                    resolved
+                } else {
+                    ty.clone()
+                }
+            }
+            _ => ty.clone(),
+        };
 
-        for (name, subty) in schema {
+        let schema = resolved_ty.properties();
+
+        for (name, mut subty) in schema {
+            if let Type::Custom(id) = &mut subty {
+                if id.symbol.is_none() {
+                    if let Some(symbol) = self.resolve(&id.value) {
+                        id.symbol = Some(symbol);
+                    }
+                }
+            }
             self.track_record_field(&RecordField {
                 name: Identifier::new(name),
                 r#type: subty,

--- a/crates/tx3-lang/src/lowering.rs
+++ b/crates/tx3-lang/src/lowering.rs
@@ -572,12 +572,20 @@ impl IntoLower for ast::PropertyOp {
     type Output = ir::Expression;
 
     fn lower(&self, ctx: &Context) -> Result<Self::Output, Error> {
-        let object = self.operand.lower(ctx)?;
-
         let ty = self
             .operand
             .target_type()
             .ok_or(Error::MissingAnalyzePhase(format!("{0:?}", self.operand)))?;
+
+        // `datum_is`-annotated operands report a `Type::Custom` datum type.
+        // Force datum context so the operand coerces to its datum (which is
+        // `Indexable`) instead of its assets (which is not), even inside
+        // amount/min_amount/change expressions.
+        let object = if matches!(ty, ast::Type::Custom(_)) {
+            self.operand.lower(&ctx.enter_datum_expr())?
+        } else {
+            self.operand.lower(ctx)?
+        };
 
         let prop_index =
             ty.property_index(*self.property.clone())
@@ -701,7 +709,7 @@ impl IntoLower for ast::InputBlockField {
                 let ctx = ctx.enter_address_expr().capturing_policy_refs();
                 x.lower(&ctx)
             }
-            ast::InputBlockField::DatumIs(_) => todo!(),
+            ast::InputBlockField::DatumIs(_) => Ok(ir::Expression::None),
             ast::InputBlockField::MinAmount(x) => {
                 let ctx = ctx.enter_asset_expr();
                 x.lower(&ctx)
@@ -1191,4 +1199,6 @@ mod tests {
     test_lowering!(param_field_shadow);
 
     test_lowering!(oracle_reference_datum);
+
+    test_lowering!(reference_datum);
 }

--- a/crates/tx3-lang/src/lowering.rs
+++ b/crates/tx3-lang/src/lowering.rs
@@ -577,15 +577,12 @@ impl IntoLower for ast::PropertyOp {
             .target_type()
             .ok_or(Error::MissingAnalyzePhase(format!("{0:?}", self.operand)))?;
 
-        // `datum_is`-annotated operands report a `Type::Custom` datum type.
-        // Force datum context so the operand coerces to its datum (which is
-        // `Indexable`) instead of its assets (which is not), even inside
+        // Property access is a structured-data read, so the operand must
+        // lower in datum context regardless of the surrounding expression:
+        // `datum_is`-annotated operands then coerce to their datum (which is
+        // `Indexable`) instead of their assets (which are not), even inside
         // amount/min_amount/change expressions.
-        let object = if matches!(ty, ast::Type::Custom(_)) {
-            self.operand.lower(&ctx.enter_datum_expr())?
-        } else {
-            self.operand.lower(ctx)?
-        };
+        let object = self.operand.lower(&ctx.enter_datum_expr())?;
 
         let prop_index =
             ty.property_index(*self.property.clone())

--- a/examples/reference_datum.pay_fee.tir
+++ b/examples/reference_datum.pay_fee.tir
@@ -1,0 +1,630 @@
+{
+  "fees": {
+    "EvalParam": "ExpectFees"
+  },
+  "references": [
+    {
+      "EvalParam": {
+        "ExpectValue": [
+          "settings_ref",
+          "UtxoRef"
+        ]
+      }
+    },
+    {
+      "EvalParam": {
+        "ExpectValue": [
+          "oracle_ref",
+          "UtxoRef"
+        ]
+      }
+    }
+  ],
+  "inputs": [
+    {
+      "name": "funds",
+      "utxos": {
+        "EvalParam": {
+          "ExpectInput": [
+            "funds",
+            {
+              "address": {
+                "EvalParam": {
+                  "ExpectValue": [
+                    "user",
+                    "Address"
+                  ]
+                }
+              },
+              "min_amount": {
+                "EvalBuiltIn": {
+                  "Add": [
+                    {
+                      "EvalBuiltIn": {
+                        "Add": [
+                          {
+                            "Assets": [
+                              {
+                                "policy": "None",
+                                "asset_name": "None",
+                                "amount": {
+                                  "EvalBuiltIn": {
+                                    "Property": [
+                                      {
+                                        "EvalCoerce": {
+                                          "IntoDatum": {
+                                            "EvalParam": {
+                                              "ExpectInput": [
+                                                "settings",
+                                                {
+                                                  "address": "None",
+                                                  "min_amount": "None",
+                                                  "ref": {
+                                                    "EvalParam": {
+                                                      "ExpectValue": [
+                                                        "settings_ref",
+                                                        "UtxoRef"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "many": false,
+                                                  "collateral": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "Number": 0
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Assets": [
+                              {
+                                "policy": "None",
+                                "asset_name": "None",
+                                "amount": {
+                                  "EvalParam": {
+                                    "ExpectValue": [
+                                      "funds_amount",
+                                      "Int"
+                                    ]
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "EvalParam": "ExpectFees"
+                    }
+                  ]
+                }
+              },
+              "ref": "None",
+              "many": false,
+              "collateral": false
+            }
+          ]
+        }
+      },
+      "redeemer": "None"
+    }
+  ],
+  "outputs": [
+    {
+      "address": {
+        "EvalParam": {
+          "ExpectValue": [
+            "vault",
+            "Address"
+          ]
+        }
+      },
+      "datum": {
+        "Struct": {
+          "constructor": 0,
+          "fields": [
+            {
+              "EvalBuiltIn": {
+                "Property": [
+                  {
+                    "EvalCoerce": {
+                      "IntoDatum": {
+                        "EvalParam": {
+                          "ExpectInput": [
+                            "settings",
+                            {
+                              "address": "None",
+                              "min_amount": "None",
+                              "ref": {
+                                "EvalParam": {
+                                  "ExpectValue": [
+                                    "settings_ref",
+                                    "UtxoRef"
+                                  ]
+                                }
+                              },
+                              "many": false,
+                              "collateral": false
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "Number": 0
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "amount": {
+        "EvalBuiltIn": {
+          "Add": [
+            {
+              "Assets": [
+                {
+                  "policy": "None",
+                  "asset_name": "None",
+                  "amount": {
+                    "EvalBuiltIn": {
+                      "Property": [
+                        {
+                          "EvalCoerce": {
+                            "IntoDatum": {
+                              "EvalParam": {
+                                "ExpectInput": [
+                                  "settings",
+                                  {
+                                    "address": "None",
+                                    "min_amount": "None",
+                                    "ref": {
+                                      "EvalParam": {
+                                        "ExpectValue": [
+                                          "settings_ref",
+                                          "UtxoRef"
+                                        ]
+                                      }
+                                    },
+                                    "many": false,
+                                    "collateral": false
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "Number": 0
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "Assets": [
+                {
+                  "policy": {
+                    "EvalBuiltIn": {
+                      "Property": [
+                        {
+                          "EvalCoerce": {
+                            "IntoDatum": {
+                              "EvalParam": {
+                                "ExpectInput": [
+                                  "settings",
+                                  {
+                                    "address": "None",
+                                    "min_amount": "None",
+                                    "ref": {
+                                      "EvalParam": {
+                                        "ExpectValue": [
+                                          "settings_ref",
+                                          "UtxoRef"
+                                        ]
+                                      }
+                                    },
+                                    "many": false,
+                                    "collateral": false
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "Number": 1
+                        }
+                      ]
+                    }
+                  },
+                  "asset_name": {
+                    "EvalBuiltIn": {
+                      "Property": [
+                        {
+                          "EvalCoerce": {
+                            "IntoDatum": {
+                              "EvalParam": {
+                                "ExpectInput": [
+                                  "settings",
+                                  {
+                                    "address": "None",
+                                    "min_amount": "None",
+                                    "ref": {
+                                      "EvalParam": {
+                                        "ExpectValue": [
+                                          "settings_ref",
+                                          "UtxoRef"
+                                        ]
+                                      }
+                                    },
+                                    "many": false,
+                                    "collateral": false
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "Number": 2
+                        }
+                      ]
+                    }
+                  },
+                  "amount": {
+                    "EvalParam": {
+                      "ExpectValue": [
+                        "share_amount",
+                        "Int"
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "optional": false
+    },
+    {
+      "address": {
+        "EvalParam": {
+          "ExpectValue": [
+            "vault",
+            "Address"
+          ]
+        }
+      },
+      "datum": "None",
+      "amount": {
+        "Assets": [
+          {
+            "policy": "None",
+            "asset_name": "None",
+            "amount": {
+              "EvalBuiltIn": {
+                "Property": [
+                  {
+                    "EvalBuiltIn": {
+                      "Property": [
+                        {
+                          "EvalCoerce": {
+                            "IntoDatum": {
+                              "EvalParam": {
+                                "ExpectInput": [
+                                  "oracle",
+                                  {
+                                    "address": "None",
+                                    "min_amount": "None",
+                                    "ref": {
+                                      "EvalParam": {
+                                        "ExpectValue": [
+                                          "oracle_ref",
+                                          "UtxoRef"
+                                        ]
+                                      }
+                                    },
+                                    "many": false,
+                                    "collateral": false
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "Number": 0
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "Number": 0
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "optional": false
+    },
+    {
+      "address": {
+        "EvalParam": {
+          "ExpectValue": [
+            "user",
+            "Address"
+          ]
+        }
+      },
+      "datum": "None",
+      "amount": {
+        "EvalBuiltIn": {
+          "Sub": [
+            {
+              "EvalBuiltIn": {
+                "Sub": [
+                  {
+                    "EvalBuiltIn": {
+                      "Sub": [
+                        {
+                          "EvalCoerce": {
+                            "IntoAssets": {
+                              "EvalParam": {
+                                "ExpectInput": [
+                                  "funds",
+                                  {
+                                    "address": {
+                                      "EvalParam": {
+                                        "ExpectValue": [
+                                          "user",
+                                          "Address"
+                                        ]
+                                      }
+                                    },
+                                    "min_amount": {
+                                      "EvalBuiltIn": {
+                                        "Add": [
+                                          {
+                                            "EvalBuiltIn": {
+                                              "Add": [
+                                                {
+                                                  "Assets": [
+                                                    {
+                                                      "policy": "None",
+                                                      "asset_name": "None",
+                                                      "amount": {
+                                                        "EvalBuiltIn": {
+                                                          "Property": [
+                                                            {
+                                                              "EvalCoerce": {
+                                                                "IntoDatum": {
+                                                                  "EvalParam": {
+                                                                    "ExpectInput": [
+                                                                      "settings",
+                                                                      {
+                                                                        "address": "None",
+                                                                        "min_amount": "None",
+                                                                        "ref": {
+                                                                          "EvalParam": {
+                                                                            "ExpectValue": [
+                                                                              "settings_ref",
+                                                                              "UtxoRef"
+                                                                            ]
+                                                                          }
+                                                                        },
+                                                                        "many": false,
+                                                                        "collateral": false
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "Number": 0
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "Assets": [
+                                                    {
+                                                      "policy": "None",
+                                                      "asset_name": "None",
+                                                      "amount": {
+                                                        "EvalParam": {
+                                                          "ExpectValue": [
+                                                            "funds_amount",
+                                                            "Int"
+                                                          ]
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "EvalParam": "ExpectFees"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "ref": "None",
+                                    "many": false,
+                                    "collateral": false
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "Assets": [
+                            {
+                              "policy": "None",
+                              "asset_name": "None",
+                              "amount": {
+                                "EvalBuiltIn": {
+                                  "Property": [
+                                    {
+                                      "EvalCoerce": {
+                                        "IntoDatum": {
+                                          "EvalParam": {
+                                            "ExpectInput": [
+                                              "settings",
+                                              {
+                                                "address": "None",
+                                                "min_amount": "None",
+                                                "ref": {
+                                                  "EvalParam": {
+                                                    "ExpectValue": [
+                                                      "settings_ref",
+                                                      "UtxoRef"
+                                                    ]
+                                                  }
+                                                },
+                                                "many": false,
+                                                "collateral": false
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "Number": 0
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "Assets": [
+                      {
+                        "policy": {
+                          "EvalBuiltIn": {
+                            "Property": [
+                              {
+                                "EvalCoerce": {
+                                  "IntoDatum": {
+                                    "EvalParam": {
+                                      "ExpectInput": [
+                                        "settings",
+                                        {
+                                          "address": "None",
+                                          "min_amount": "None",
+                                          "ref": {
+                                            "EvalParam": {
+                                              "ExpectValue": [
+                                                "settings_ref",
+                                                "UtxoRef"
+                                              ]
+                                            }
+                                          },
+                                          "many": false,
+                                          "collateral": false
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "Number": 1
+                              }
+                            ]
+                          }
+                        },
+                        "asset_name": {
+                          "EvalBuiltIn": {
+                            "Property": [
+                              {
+                                "EvalCoerce": {
+                                  "IntoDatum": {
+                                    "EvalParam": {
+                                      "ExpectInput": [
+                                        "settings",
+                                        {
+                                          "address": "None",
+                                          "min_amount": "None",
+                                          "ref": {
+                                            "EvalParam": {
+                                              "ExpectValue": [
+                                                "settings_ref",
+                                                "UtxoRef"
+                                              ]
+                                            }
+                                          },
+                                          "many": false,
+                                          "collateral": false
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "Number": 2
+                              }
+                            ]
+                          }
+                        },
+                        "amount": {
+                          "EvalParam": {
+                            "ExpectValue": [
+                              "share_amount",
+                              "Int"
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "EvalParam": "ExpectFees"
+            }
+          ]
+        }
+      },
+      "optional": false
+    }
+  ],
+  "validity": null,
+  "mints": [],
+  "burns": [],
+  "adhoc": [],
+  "collateral": [],
+  "signers": null,
+  "metadata": []
+}

--- a/examples/reference_datum.tx3
+++ b/examples/reference_datum.tx3
@@ -1,0 +1,67 @@
+/// Reference-datum field access across every expression context:
+/// `Ada(...)` amount, `min_amount`, change math, `AnyAsset(...)`, datum
+/// construction, and multi-level nested access (`ref.outer.inner`).
+
+party User;
+party Vault;
+
+type SettingsDatum {
+    fee: Int,
+    token_policy: Bytes,
+    token_name: Bytes,
+}
+
+type FeedReport {
+    price: Int,
+}
+
+type OracleDatum {
+    feed: FeedReport,
+}
+
+type EchoDatum {
+    echoed_fee: Int,
+}
+
+env {
+    settings_ref: UtxoRef,
+    oracle_ref: UtxoRef,
+}
+
+tx pay_fee(
+    funds_amount: Int,
+    share_amount: Int,
+) {
+    reference settings {
+        ref: settings_ref,
+        datum_is: SettingsDatum,
+    }
+
+    reference oracle {
+        ref: oracle_ref,
+        datum_is: OracleDatum,
+    }
+
+    input funds {
+        from: User,
+        min_amount: Ada(settings.fee) + Ada(funds_amount) + fees,
+    }
+
+    output paid {
+        to: Vault,
+        amount: Ada(settings.fee) + AnyAsset(settings.token_policy, settings.token_name, share_amount),
+        datum: EchoDatum {
+            echoed_fee: settings.fee,
+        },
+    }
+
+    output oracle_echo {
+        to: Vault,
+        amount: Ada(oracle.feed.price),
+    }
+
+    output change {
+        to: User,
+        amount: funds - Ada(settings.fee) - AnyAsset(settings.token_policy, settings.token_name, share_amount) - fees,
+    }
+}


### PR DESCRIPTION
## Summary

Fix `reference { datum_is }` field access inside amount expressions (`Ada(...)`, `min_amount`, `AnyAsset(...)`, change math) and multi-level nested access (`ref.outer.inner`).

Closes #286.

## Problem

`PropertyOp::lower` lowered the operand with the inherited expression context. Inside `amount:` / `min_amount:` blocks (asset-expr context), a `datum_is`-annotated reference lowered through `Coerce::IntoAssets`, reducing to `Assets(...)` — which is not `Indexable`. `Property(Assets(...), idx)` then failed with `property index N not found in Assets([...])` or `expected assets, got EvalBuiltIn(Add(...))`.

Field access only worked inside `output.datum:` construction (datum-expr context), where the reference correctly lowered through `IntoDatum`.

## Fix

1. **`PropertyOp::lower`** — always lower the operand in datum context (`enter_datum_expr`): property access is a structured-data read, regardless of the surrounding expression. A `datum_is`-annotated reference/input then coerces through `IntoDatum` → the decoded `Struct` datum, which is `Indexable`. Non-coercing operands (params, record fields) ignore the expression context, so this is a no-op for them — and it covers non-record `datum_is` types (e.g. tuples), which a `Type::Custom`-only guard would miss.

2. **`track_record_fields_for_type`** (analyzer) — re-resolve `Type::Custom` identifiers (and nested field sub-types) against the scope when they carry a stale `None` symbol. `track_type_def` clones the def before field-type analysis resolves the original, so cloned nested types lost their symbol — blocking multi-level access at analysis and lowering. This unblocks single-case nested struct access (`ref.outer.inner`).

3. **`InputBlockField::DatumIs`** — replaced latent `todo!()` with `Ok(Expression::None)` (cleanup; this arm was unreachable since `InputBlock::lower` builds queries via `find()` and never lowers `datum_is` through it).

## Test coverage

- `examples/reference_datum.tx3` + snapshot — comprehensive fixture covering field-in-amount, `min_amount`, change math, `AnyAsset`, datum construction, and multi-level access.
- `test_lowering!(reference_datum)` — smoke test matching the lowered TIR snapshot.
- `test_property_access_on_into_datum_from_utxo_set` (tx3-tir PR #10) — proves `Property(IntoDatum(UtxoSet), idx)` reduces to the datum field, single-level and nested.

## Verification

```
cargo test -p tx3-lang --lib   # 185 passed
cargo test -p tx3-resolver     # 23 passed
cargo test -p tx3-tir --lib    # 60 passed
cargo clippy -p tx3-lang       # clean
```

Protocol builds unchanged: githoney, bodega, oracle all `tx3c build` cleanly.

